### PR TITLE
Addition of syntactic sugar in Scala for MapReduce classes, Scala Implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.bespin</groupId>
@@ -76,6 +76,16 @@
             </goals>
           </execution>
           <execution>
+            <id>scala-integration-test-add</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <testSourceDir>src/it/scala</testSourceDir>
+            </configuration>
+          </execution>
+          <execution>
             <id>scala-test-compile</id>
             <phase>process-test-resources</phase>
             <goals>
@@ -114,6 +124,46 @@
                   </excludes>
                 </filter>
               </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- disable surefire tests-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <!--enable scalatest -->
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>1.0</version>
+        <configuration>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          <junitxml>.</junitxml>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <suffixes>(?&lt;!IT)</suffixes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <suffixes>(?&lt;=IT)</suffixes>
             </configuration>
           </execution>
         </executions>
@@ -178,6 +228,12 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
       <version>${spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.10</artifactId>
+      <version>2.2.6</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/it/resources/log4j.properties
+++ b/src/it/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=WARN, stdout
+
+# Redirect log messages to console
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/it/scala/io/bespin/scala/mapreduce/BfsLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/BfsLocalIT.scala
@@ -1,0 +1,95 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util._
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class BfsLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with IterableKVTest[Int, (Int, Int)] with WithExternalFile{
+
+  private val tupleRegex = "\\{(\\d+) (\\d+) \\[(.*)\\]\\}".r
+  override protected def tupleConv(key: String, value: String): (Int, (Int, Int)) = {
+    val s = value match {
+      case tupleRegex(selfNode, dist, connected) =>
+        (selfNode.toInt, dist.toInt)
+    }
+    (key.toInt, s)
+  }
+
+  override protected val iterations: Int = 15
+  override protected def resultDir: String = outputDir + s"/reachable-iter000$iterations"
+
+  s"BFS:$suiteName" should "find all reachable nodes after 15 iterations" in programOutput { map =>
+    map.size shouldBe 6028
+  }
+
+  it should "get correct distance for 367" in programOutput { map =>
+    map(367)._2 shouldBe 0
+  }
+
+  it should "find correct distance for node 101" in programOutput { map =>
+    map(101)._2 shouldBe 6
+  }
+
+  it should "find correct distance for node 201" in programOutput { map =>
+    map(201)._2 shouldBe 8
+  }
+
+  it should "find correct distance for node 6276" in programOutput { map =>
+    map(6276)._2 shouldBe 13
+  }
+
+  it should "find correct distance for node 6258" in programOutput { map =>
+    map(6258)._2 shouldBe 11
+  }
+
+  it should "find correct distance for node 909" in programOutput { map =>
+    map(909)._2 shouldBe 4
+  }
+
+  it should "find correct distance for node 5664" in programOutput { map =>
+    map(5664)._2 shouldBe 7
+  }
+}
+
+class BfsJavaIT extends BfsLocalIT(TestConstants.Graph_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.bfs.EncodeBfsGraph, Array(
+      "-input", filePath,
+      "-output", outputDir + "/" + "iter0000",
+      "-src", "367"
+    ))
+
+  override protected def iterJob(itr: Int): Any = {
+    ToolRunner.run(new io.bespin.java.mapreduce.bfs.IterateBfs, Array(
+      "-input", outputDir + "/" + s"iter000$itr",
+      "-output", outputDir + "/" + s"iter000${itr + 1}",
+      "-partitions", "5"
+    ))
+    ToolRunner.run(new io.bespin.java.mapreduce.bfs.FindReachableNodes, Array(
+      "-input", outputDir + "/" + s"iter000${itr + 1}",
+      "-output", outputDir + "/" + s"reachable-iter000${itr + 1}"
+    ))
+  }
+}
+
+class BfsScalaIT extends BfsLocalIT(TestConstants.Graph_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.bfs.EncodeBfsGraph, Array(
+      "--input", filePath,
+      "--output", outputDir + "/" + "iter0000",
+      "--src", "367"
+    ))
+
+  override protected def iterJob(itr: Int): Any = {
+    ToolRunner.run(io.bespin.scala.mapreduce.bfs.IterateBfs, Array(
+      "--input", outputDir + "/" + s"iter000$itr",
+      "--output", outputDir + "/" + s"iter000${itr + 1}",
+      "--partitions", "5"
+    ))
+    ToolRunner.run(io.bespin.scala.mapreduce.bfs.FindReachableNodes, Array(
+      "--input", outputDir + "/" + s"iter000${itr + 1}",
+      "--output", outputDir + "/" + s"reachable-iter000${itr + 1}"
+    ))
+  }
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/BigramCountLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/BigramCountLocalIT.scala
@@ -1,0 +1,50 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util._
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class BigramCountLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[String, Long] with WithExternalFile {
+
+  override protected def tupleConv(key: String, value: String): (String, Long) = (key, value.toLong)
+
+  s"BigramCount:$suiteName" should "produce expected count for 'a baboon'" in programOutput { map =>
+    map("a baboon") shouldBe 1
+  }
+
+  it should "produce expected count for 'poor yorick'" in programOutput { map =>
+    map("poor yorick") shouldBe 1
+  }
+
+  it should "produce expected count for 'dream again'" in programOutput { map =>
+    map("dream again") shouldBe 2
+  }
+
+  it should "produce expected count for 'dream away'" in programOutput { map =>
+    map("dream away") shouldBe 2
+  }
+
+  it should "produce expected count for 'dream as'" in programOutput { map =>
+    map("dream as") shouldBe 1
+  }
+
+}
+
+class BigramCountScalaIT extends BigramCountLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.bigram.BigramCount, Array(
+      "--input", filePath,
+      "--output", outputDir,
+      "--reducers", "1"
+    ))
+}
+
+class BigramCountJavaIT extends BigramCountLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.bigram.BigramCount, Array(
+      "-input", filePath,
+      "-output", outputDir,
+      "-reducers", "1"
+    ))
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/BooleanRetrievalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/BooleanRetrievalIT.scala
@@ -1,0 +1,102 @@
+package io.bespin.scala.mapreduce
+
+import java.io.{ByteArrayInputStream, PrintStream}
+
+import io.bespin.scala.util.{TestConstants, TestLogging, WithExternalFile, WithTempOutputDir}
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.collection.immutable.TreeMap
+
+abstract sealed class BooleanRetrievalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging
+    with BeforeAndAfterAll with WithTempOutputDir with WithExternalFile {
+
+  protected final case class RetrievalResult(occurrences: TreeMap[Int, String])
+
+  protected def runQuery(queryString: String): Unit
+
+  private val resultRegex = "(\\d+)\t(.*)".r
+
+  private def retrievalOutput(queryString: String)(f: RetrievalResult => Any): Unit = {
+    val stream = new java.io.ByteArrayOutputStream()
+    val originalOutStream = System.out
+    val interceptionStream = new PrintStream(stream)
+    // Temporarily redirect stdout to a stream we can capture
+    System.setOut(interceptionStream)
+    Console.withOut(stream) {
+      runQuery(queryString)
+    }
+    System.setOut(originalOutStream)
+    val input = new ByteArrayInputStream(stream.toByteArray)
+
+    val builder = TreeMap.newBuilder[Int, String]
+    scala.io.Source.fromInputStream(input).getLines().foreach {
+      case resultRegex(num, str) => builder += ((num.toInt, str.trim))
+      case _ =>
+    }
+
+    f(RetrievalResult(builder.result()))
+  }
+
+
+  s"BooleanRetrieval:$suiteName" should "produce expected count for 'poor'" in retrievalOutput("poor") { results =>
+    results.occurrences.size shouldBe 623
+  }
+
+  it should "produce expected count for 'white red OR rose AND pluck AND'" in retrievalOutput("white red OR rose AND pluck AND") { results =>
+    results.occurrences.size shouldBe 5
+  }
+
+  it should "produce expected lines for 'white red OR rose AND pluck AND'" in retrievalOutput("white red OR rose AND pluck AND") { results =>
+    results.occurrences.values.head shouldBe "From off this brier pluck a white rose with me."
+  }
+
+  it should "produce expected lines for 'poor yorick AND'" in retrievalOutput("poor yorick AND") { results =>
+    results.occurrences.size shouldBe 1
+    results.occurrences.values.head should include ("Alas, poor Yorick!")
+  }
+
+  it should "produce nothing for query with no result" in retrievalOutput("romeo hamlet AND") { results =>
+    results.occurrences shouldBe empty
+  }
+
+  it should "produce expected lines for 'romeo juliet AND'" in retrievalOutput("romeo juliet AND") { results =>
+    results.occurrences.values.head should startWith ("THE TRAGEDY")
+  }
+
+}
+
+class BooleanRetrievalScalaIT extends BooleanRetrievalIT(TestConstants.Shakespeare_Url) {
+  override def beforeAll = {
+    super.beforeAll
+    ToolRunner.run(io.bespin.scala.mapreduce.search.BuildInvertedIndex, Array(
+      "--input", filePath,
+      "--output", outputDir + "/index"
+    ))
+  }
+
+  override protected def runQuery(queryString: String): Unit =
+    ToolRunner.run(io.bespin.scala.mapreduce.search.BooleanRetrieval, Array(
+      "--index", outputDir + "/index",
+      "--collection", filePath,
+      "--query", queryString
+    ))
+}
+
+class BooleanRetrievalJavaIT extends BooleanRetrievalIT(TestConstants.Shakespeare_Url) {
+  override def beforeAll = {
+    super.beforeAll
+    ToolRunner.run(new io.bespin.java.mapreduce.search.BuildInvertedIndex, Array(
+      "-input", filePath,
+      "-output", outputDir + "/index"
+    ))
+  }
+
+  override protected def runQuery(queryString: String): Unit =
+    ToolRunner.run(new io.bespin.java.mapreduce.search.BooleanRetrieval, Array(
+      "-index", outputDir + "/index",
+      "-collection", filePath,
+      "-query", queryString
+    ))
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/CoocurrencePairsLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/CoocurrencePairsLocalIT.scala
@@ -1,0 +1,55 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util._
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class CoocurrencePairsLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[(String, String), Long] with WithExternalFile {
+
+  private val tupleRegex = "\\((.*), (.*)\\)".r
+  override protected def tupleConv(key: String, value: String): ((String, String), Long) = key match {
+    case tupleRegex(l, r) => ((l, r), value.toLong)
+  }
+
+  s"Cooccurrence-pairs:$suiteName" should "get correct co-occurrences for (the, of)" in programOutput { map =>
+    map(("the", "of")) shouldBe 5974
+  }
+
+  it should "get correct co-occurrences for (the, and)" in programOutput { map =>
+    map(("the", "and")) shouldBe 2923
+  }
+
+  it should "get correct co-occurrences for (i, am)" in programOutput { map =>
+    map(("i", "am")) shouldBe 2110
+  }
+
+  it should "get correct co-occurrences for (poor, yorick)" in programOutput { map =>
+    map(("poor", "yorick")) shouldBe 1
+  }
+
+  it should "get correct co-occurrences for (slings, arrows)" in programOutput { map =>
+    map(("slings", "arrows")) shouldBe 1
+  }
+
+}
+
+class CoocurrencePairsScalaIT extends CoocurrencePairsLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.cooccur.ComputeCooccurrenceMatrixPairs, Array(
+      "--input", filePath,
+      "--output", outputDir,
+      "--window", "2",
+      "--reducers", "1"
+    ))
+}
+
+class CoocurrencePairsJavaIT extends CoocurrencePairsLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.cooccur.ComputeCooccurrenceMatrixPairs, Array(
+      "-input", filePath,
+      "-output", outputDir,
+      "-window", "2",
+      "-reducers", "1"
+    ))
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/CoocurrenceStripesLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/CoocurrenceStripesLocalIT.scala
@@ -1,0 +1,62 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util._
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class CoocurrenceStripesLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[String, Map[String, Long]] with WithExternalFile {
+
+  private val tupleRegex = "(.*)=(.*)".r
+  override protected def tupleConv(key: String, value: String): (String, Map[String, Long]) = {
+    val map = value.stripPrefix("{").stripSuffix("}").split(", ").map(_.trim).collect {
+      case tupleRegex(l, r) => l -> r.toLong
+    }.toMap
+    (key, map)
+  }
+
+  s"Cooccurrence-stripes:$suiteName" should "get correct co-occurrences for (the, of)" in programOutput { map =>
+    map("the")("of") shouldBe 5974
+  }
+
+  it should "get correct co-occurrences for (the, and)" in programOutput { map =>
+    map("the")("and") shouldBe 2923
+  }
+
+  it should "get correct co-occurrences for (i, am)" in programOutput { map =>
+    map("i")("am") shouldBe 2110
+  }
+
+  it should "get correct co-occurrences for (poor, yorick)" in programOutput { map =>
+    map("poor")("yorick") shouldBe 1
+  }
+
+  it should "get correct co-occurrences for (slings, arrows)" in programOutput { map =>
+    map("slings")("arrows") shouldBe 1
+  }
+
+  it should "get correct total count for co-occurrences with (dream *)" in programOutput { map =>
+    map("dream").values.sum shouldBe 374
+  }
+
+}
+
+class CoocurrenceStripesScalaIT extends CoocurrenceStripesLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.cooccur.ComputeCooccurrenceMatrixStripes, Array(
+      "--input", filePath,
+      "--output", outputDir,
+      "--window", "2",
+      "--reducers", "1"
+    ))
+}
+
+class CoocurrenceStripesJavaIT extends CoocurrenceStripesLocalIT(TestConstants.Shakespeare_Url) {
+  override protected def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.cooccur.ComputeCooccurrenceMatrixStripes, Array(
+      "-input", filePath,
+      "-output", outputDir,
+      "-window", "2",
+      "-reducers", "1"
+    ))
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/PageRankLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/PageRankLocalIT.scala
@@ -1,0 +1,267 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util.{SingleKVTest, TestConstants, TestLogging, WithExternalFile}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class PageRankLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[Int, Float] with WithExternalFile {
+
+  override protected def tupleConv(key: String, value: String): (Int, Float) = {
+    (key.toInt, value.toFloat)
+  }
+
+  protected val Epsilon = 0.0001f
+  protected val pageRankIterations = 10
+  protected val expectedNodes = 6301
+  protected val pageRankRecordsDir = outputDir + "/PageRankRecords/"
+  protected val pageRankIterDir = outputDir + "/PageRankIter/"
+  protected def iterDir(i: Int): String = pageRankIterDir + "iter%04d/".format(i)
+  protected override val resultDir = outputDir + "/PageRankTop20/"
+
+  s"PageRank:$suiteName" should "contain the correctly-extracted top 20 nodes" in programOutput { map =>
+    map.size shouldBe 20
+  }
+
+  it should "return correct PageRank value for node 367" in programOutput { map =>
+    map(367) shouldEqual  -6.037346f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 249" in programOutput { map =>
+    map(249) shouldEqual -6.126378f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 145" in programOutput { map =>
+    map(145) shouldEqual -6.187434f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 264" in programOutput { map =>
+    map(264) shouldEqual -6.2151237f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 266" in programOutput { map =>
+    map(266) shouldEqual -6.2329774f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 4" in programOutput { map =>
+    map(4) shouldEqual -6.4705563f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 7" in programOutput { map =>
+    map(7) shouldEqual -6.501463f +- Epsilon
+  }
+}
+
+abstract sealed class PageRankScala(url: String) extends PageRankLocalIT(url) {
+  def setup(rangePartition: Boolean = false): Unit = {
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.BuildPageRankRecords, Array(
+      "--input", filePath,
+      "--output", pageRankRecordsDir,
+      "--num-nodes", expectedNodes.toString
+    ))
+    FileSystem.get(new Configuration()).mkdirs(new Path(pageRankIterDir))
+    if(rangePartition) {
+      ToolRunner.run(io.bespin.scala.mapreduce.pagerank.PartitionGraph, Array(
+        "--input", pageRankRecordsDir,
+        "--output", iterDir(0),
+        "--num-partitions", "5",
+        "--num-nodes", expectedNodes.toString,
+        "--range"
+      ))
+    } else {
+      ToolRunner.run(io.bespin.scala.mapreduce.pagerank.PartitionGraph, Array(
+        "--input", pageRankRecordsDir,
+        "--output", iterDir(0),
+        "--num-partitions", "5",
+        "--num-nodes", expectedNodes.toString
+      ))
+    }
+  }
+
+  def countMax = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.FindMaxPageRankNodes, Array(
+      "-input", iterDir(pageRankIterations),
+      "-output", resultDir,
+      "-top", "20"
+    ))
+  }
+}
+
+abstract sealed class PageRankJava(url: String) extends PageRankLocalIT(url) {
+  def setup(rangePartition: Boolean = false): Unit = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.BuildPageRankRecords, Array(
+      "-input", filePath,
+      "-output", pageRankRecordsDir,
+      "-numNodes", expectedNodes.toString
+    ))
+    FileSystem.get(new Configuration()).mkdirs(new Path(pageRankIterDir))
+    if(rangePartition) {
+      ToolRunner.run(new io.bespin.java.mapreduce.pagerank.PartitionGraph, Array(
+        "-input", pageRankRecordsDir,
+        "-output", iterDir(0),
+        "-numPartitions", "5",
+        "-numNodes", expectedNodes.toString,
+        "-range"
+      ))
+    } else {
+      ToolRunner.run(new io.bespin.java.mapreduce.pagerank.PartitionGraph, Array(
+        "-input", pageRankRecordsDir,
+        "-output", iterDir(0),
+        "-numPartitions", "5",
+        "-numNodes", expectedNodes.toString
+      ))
+    }
+  }
+
+  def countMax = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.FindMaxPageRankNodes, Array(
+      "-input", iterDir(pageRankIterations),
+      "-output", resultDir,
+      "-top", "20"
+    ))
+  }
+}
+
+class PageRankScalaIT extends PageRankScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankBasic, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString
+    ))
+    countMax
+  }
+}
+
+class PageRankJavaIT extends PageRankJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankBasic, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString
+    ))
+    countMax
+  }
+}
+
+class PageRankRangeScalaIT extends PageRankScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(rangePartition = true)
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankBasic, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--range"
+    ))
+    countMax
+  }
+}
+
+class PageRankRangeJavaIT extends PageRankJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(rangePartition = true)
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankBasic, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-range"
+    ))
+    countMax
+  }
+}
+
+class PageRankIMCScalaIT extends PageRankScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankBasic, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-in-mapper-combiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankIMCJavaIT extends PageRankJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankBasic, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useInMapperCombiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankCombinerScalaIT extends PageRankScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankBasic, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-combiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankCombinerJavaIT extends PageRankJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankBasic, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useCombiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankEverythingScalaIT extends PageRankScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(true)
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankBasic, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-combiner",
+      "--use-in-mapper-combiner",
+      "--range"
+    ))
+    countMax
+  }
+}
+
+class PageRankEverythingJavaIT extends PageRankJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(true)
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankBasic, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useCombiner",
+      "-useInMapperCombiner",
+      "-range"
+    ))
+    countMax
+  }
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/PageRankSchimmyLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/PageRankSchimmyLocalIT.scala
@@ -1,0 +1,267 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util.{SingleKVTest, TestConstants, TestLogging, WithExternalFile}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class PageRankSchimmyLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[Int, Float] with WithExternalFile {
+
+  override protected def tupleConv(key: String, value: String): (Int, Float) = {
+    (key.toInt, value.toFloat)
+  }
+
+  protected val Epsilon = 0.01f
+  protected val pageRankIterations = 10
+  protected val expectedNodes = 6301
+  protected val pageRankRecordsDir = outputDir + "/PageRankRecords/"
+  protected val pageRankIterDir = outputDir + "/PageRankIter/"
+  protected def iterDir(i: Int): String = pageRankIterDir + "iter%04d/".format(i)
+  protected override val resultDir = outputDir + "/PageRankTop20/"
+
+  s"PageRank:$suiteName" should "contain the correctly-extracted top 20 nodes" in programOutput { map =>
+    map.size shouldBe 20
+  }
+
+  it should "return correct PageRank value for node 367" in programOutput { map =>
+    map(367) shouldEqual  -6.0344872f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 249" in programOutput { map =>
+    map(249) shouldEqual -6.123314f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 145" in programOutput { map =>
+    map(145) shouldEqual -6.1849885f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 264" in programOutput { map =>
+    map(264) shouldEqual -6.212695f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 266" in programOutput { map =>
+    map(266) shouldEqual -6.2296443f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 4" in programOutput { map =>
+    map(4) shouldEqual -6.4672594f +- Epsilon
+  }
+
+  it should "return correct PageRank value for node 7" in programOutput { map =>
+    map(7) shouldEqual -6.4994793f +- Epsilon
+  }
+}
+
+abstract sealed class PageRankSchimmyScala(url: String) extends PageRankSchimmyLocalIT(url) {
+  def setup(rangePartition: Boolean = false): Unit = {
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.BuildPageRankRecords, Array(
+      "--input", filePath,
+      "--output", pageRankRecordsDir,
+      "--num-nodes", expectedNodes.toString
+    ))
+    FileSystem.get(new Configuration()).mkdirs(new Path(pageRankIterDir))
+    if(rangePartition) {
+      ToolRunner.run(io.bespin.scala.mapreduce.pagerank.PartitionGraph, Array(
+        "--input", pageRankRecordsDir,
+        "--output", iterDir(0),
+        "--num-partitions", "5",
+        "--num-nodes", expectedNodes.toString,
+        "--range"
+      ))
+    } else {
+      ToolRunner.run(io.bespin.scala.mapreduce.pagerank.PartitionGraph, Array(
+        "--input", pageRankRecordsDir,
+        "--output", iterDir(0),
+        "--num-partitions", "5",
+        "--num-nodes", expectedNodes.toString
+      ))
+    }
+  }
+
+  def countMax = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.FindMaxPageRankNodes, Array(
+      "-input", iterDir(pageRankIterations),
+      "-output", resultDir,
+      "-top", "20"
+    ))
+  }
+}
+
+abstract sealed class PageRankSchimmyJava(url: String) extends PageRankSchimmyLocalIT(url) {
+  def setup(rangePartition: Boolean = false): Unit = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.BuildPageRankRecords, Array(
+      "-input", filePath,
+      "-output", pageRankRecordsDir,
+      "-numNodes", expectedNodes.toString
+    ))
+    FileSystem.get(new Configuration()).mkdirs(new Path(pageRankIterDir))
+    if(rangePartition) {
+      ToolRunner.run(new io.bespin.java.mapreduce.pagerank.PartitionGraph, Array(
+        "-input", pageRankRecordsDir,
+        "-output", iterDir(0),
+        "-numPartitions", "5",
+        "-numNodes", expectedNodes.toString,
+        "-range"
+      ))
+    } else {
+      ToolRunner.run(new io.bespin.java.mapreduce.pagerank.PartitionGraph, Array(
+        "-input", pageRankRecordsDir,
+        "-output", iterDir(0),
+        "-numPartitions", "5",
+        "-numNodes", expectedNodes.toString
+      ))
+    }
+  }
+
+  def countMax = {
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.FindMaxPageRankNodes, Array(
+      "-input", iterDir(pageRankIterations),
+      "-output", resultDir,
+      "-top", "20"
+    ))
+  }
+}
+
+class PageRankSchimmyScalaIT extends PageRankSchimmyScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyJavaIT extends PageRankSchimmyJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyRangeScalaIT extends PageRankSchimmyScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(rangePartition = true)
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--range"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyRangeJavaIT extends PageRankSchimmyJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(rangePartition = true)
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-range"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyIMCScalaIT extends PageRankSchimmyScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-in-mapper-combiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyIMCJavaIT extends PageRankSchimmyJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useInMapperCombiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyCombinerScalaIT extends PageRankSchimmyScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-combiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyCombinerJavaIT extends PageRankSchimmyJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup()
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useCombiner"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyEverythingScalaIT extends PageRankSchimmyScala(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(true)
+    ToolRunner.run(io.bespin.scala.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "--base", pageRankIterDir,
+      "--start", "0",
+      "--end", pageRankIterations.toString,
+      "--num-nodes", expectedNodes.toString,
+      "--use-combiner",
+      "--use-in-mapper-combiner",
+      "--range"
+    ))
+    countMax
+  }
+}
+
+class PageRankSchimmyEverythingJavaIT extends PageRankSchimmyJava(TestConstants.Graph_Url) {
+  override protected def initialJob = {
+    setup(true)
+    ToolRunner.run(new io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy, Array(
+      "-base", pageRankIterDir,
+      "-start", "0",
+      "-end", pageRankIterations.toString,
+      "-numNodes", expectedNodes.toString,
+      "-useCombiner",
+      "-useInMapperCombiner",
+      "-range"
+    ))
+    countMax
+  }
+}

--- a/src/it/scala/io/bespin/scala/mapreduce/WordCountLocalIT.scala
+++ b/src/it/scala/io/bespin/scala/mapreduce/WordCountLocalIT.scala
@@ -1,0 +1,58 @@
+package io.bespin.scala.mapreduce
+
+import io.bespin.scala.util._
+import org.apache.hadoop.util.ToolRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+sealed abstract class WordCountLocalIT(override val url: String)
+  extends FlatSpec with Matchers with TestLogging with SingleKVTest[String, Long] with WithExternalFile {
+
+  override protected def tupleConv(key: String, value: String): (String, Long) = (key, value.toLong)
+
+  s"Wordcount:$suiteName" should "produce expected count for 'a'" in programOutput { map =>
+    map("a") shouldBe 14593
+  }
+
+  it should "produce expected count for 'hamlet'" in programOutput { map =>
+    map("hamlet") shouldBe 107
+  }
+
+}
+
+class WordCountScalaIT extends WordCountLocalIT(TestConstants.Shakespeare_Url) {
+  override def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.wordcount.WordCount, Array(
+      "--input", filePath,
+      "--output", outputDir,
+      "--reducers", "1"
+    ))
+}
+
+class WordCountIMCScalaIT extends WordCountLocalIT(TestConstants.Shakespeare_Url) {
+  override def initialJob: Any =
+    ToolRunner.run(io.bespin.scala.mapreduce.wordcount.WordCount, Array(
+      "--input", filePath,
+      "--output", outputDir,
+      "--reducers", "1",
+      "--imc"
+    ))
+}
+
+class WordCountJavaIT extends WordCountLocalIT(TestConstants.Shakespeare_Url) {
+  override def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.wordcount.WordCount, Array(
+      "-input", filePath,
+      "-output", outputDir,
+      "-reducers", "1"
+    ))
+}
+
+class WordCountIMCJavaIT extends WordCountLocalIT(TestConstants.Shakespeare_Url) {
+  override def initialJob: Any =
+    ToolRunner.run(new io.bespin.java.mapreduce.wordcount.WordCount, Array(
+      "-input", filePath,
+      "-output", outputDir,
+      "-reducers", "1",
+      "-imc"
+    ))
+}

--- a/src/it/scala/io/bespin/scala/util/TestConstants.scala
+++ b/src/it/scala/io/bespin/scala/util/TestConstants.scala
@@ -1,0 +1,6 @@
+package io.bespin.scala.util
+
+object TestConstants {
+  val Graph_Url = "http://lintool.github.io/bespin-data/p2p-Gnutella08-adj.txt"
+  val Shakespeare_Url = "http://lintool.github.io/bespin-data/Shakespeare.txt"
+}

--- a/src/it/scala/io/bespin/scala/util/TestFixtures.scala
+++ b/src/it/scala/io/bespin/scala/util/TestFixtures.scala
@@ -1,0 +1,104 @@
+package io.bespin.scala.util
+
+import java.net.{URI, URL}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import scala.collection.mutable
+import scala.io.Source
+
+trait WithTempOutputDir { self: Suite =>
+  protected val outputDir = URI.create(System.getProperty("java.io.tmpdir") + "/" + suiteName).toString
+  protected def resultDir = outputDir
+}
+
+sealed trait SingleJobFixture extends WithTempOutputDir with BeforeAndAfterAll { self: Suite with TestLogging =>
+  protected def initialJob: Any
+
+  override def beforeAll = {
+    log.info(s"Running initial job for suite $suiteName")
+    initialJob
+    log.info(s"Initial job for $suiteName complete.")
+  }
+
+  override final def afterAll = {
+    FileSystem.get(new Configuration()).delete(new Path(outputDir), true)
+  }
+}
+
+sealed trait IterableJobFixture extends SingleJobFixture { self: Suite with TestLogging =>
+  protected def iterations: Int
+
+  protected def iterJob(iter: Int): Any
+
+  override def beforeAll = {
+    super.beforeAll
+    for(i <- 0 until iterations) {
+      log.info(s"Running iteration $i of initial job for suite $suiteName")
+      iterJob(i)
+      log.info(s"Iteration $i of initial job for suite $suiteName")
+    }
+  }
+}
+
+sealed trait KVDictJobFixture[K, V] extends WithTempOutputDir with BeforeAndAfterAll { self: Suite with TestLogging =>
+  protected def tupleConv(key: String, value: String): (K, V)
+
+  private val valueDict: scala.collection.mutable.Map[K, V] = new mutable.HashMap()
+
+  final def programOutput(f: collection.Map[K, V] => Any) {
+    f(valueDict)
+  }
+
+  override def beforeAll = {
+    super.beforeAll
+    FileSystem.get(new Configuration()).listStatus(new Path(resultDir))
+      .withFilter(_.getPath.getName.startsWith("part-"))
+      .foreach { s =>
+        val fileStream = FileSystem.get(new Configuration()).open(s.getPath)
+        val reader = Source.fromInputStream(fileStream)
+        reader.getLines().foreach { line =>
+          val res = line.split("\t")
+          val conv = tupleConv(res(0), res(1))
+          valueDict.put(conv._1, conv._2)
+        }
+      }
+  }
+}
+
+trait SingleKVTest[K,V] extends SingleJobFixture with KVDictJobFixture[K,V] { self: Suite with TestLogging => }
+trait IterableKVTest[K,V] extends IterableJobFixture with KVDictJobFixture[K,V] { self: Suite with TestLogging => }
+
+trait WithExternalFile extends BeforeAndAfterAll { self: Suite with TestLogging =>
+  def url: String
+  private lazy val urlObj = new URL(url)
+  private lazy val fileDir = URI.create(System.getProperty("java.io.tmpdir"))
+
+  lazy val filePath = fileDir.getPath + "/" + urlObj.getFile
+
+  override def beforeAll = {
+    val conf = new Configuration()
+    val path = new Path(filePath)
+    if(FileSystem.get(conf).exists(path)) {
+      log.info(s"Found existing data at $filePath.")
+    } else {
+      log.info(s"Existing data not found, fetching $url.")
+      try {
+        val source = scala.io.Source.fromURL(url)
+        val fs = FileSystem.get(conf).create(path)
+        while(source.hasNext) {
+          fs.write(source.next)
+        }
+        fs.close()
+        source.close()
+      } catch {
+        case e: Exception =>
+          log.error(s"Error retrieving test file from $url: $e")
+          throw e
+      }
+    }
+    super.beforeAll
+  }
+}

--- a/src/it/scala/io/bespin/scala/util/TestLogging.scala
+++ b/src/it/scala/io/bespin/scala/util/TestLogging.scala
@@ -1,0 +1,7 @@
+package io.bespin.scala.util
+
+import org.apache.log4j.Logger
+
+trait TestLogging { self =>
+  lazy val log = Logger.getLogger(self.getClass)
+}

--- a/src/main/java/io/bespin/java/mapreduce/bfs/BfsNode.java
+++ b/src/main/java/io/bespin/java/mapreduce/bfs/BfsNode.java
@@ -35,7 +35,7 @@ public class BfsNode implements Writable {
   private Type type;
   private int nodeid;
   private int distance;
-  private ArrayListOfIntsWritable adjacenyList;
+  private ArrayListOfIntsWritable adjacencyList;
 
   public BfsNode() {}
 
@@ -55,12 +55,12 @@ public class BfsNode implements Writable {
     nodeid = n;
   }
 
-  public ArrayListOfIntsWritable getAdjacenyList() {
-    return adjacenyList;
+  public ArrayListOfIntsWritable getAdjacencyList() {
+    return adjacencyList;
   }
 
   public void setAdjacencyList(ArrayListOfIntsWritable l) {
-    adjacenyList = l;
+    adjacencyList = l;
   }
 
   public Type getType() {
@@ -91,8 +91,8 @@ public class BfsNode implements Writable {
       distance = in.readInt();
     }
 
-    adjacenyList = new ArrayListOfIntsWritable();
-    adjacenyList.readFields(in);
+    adjacencyList = new ArrayListOfIntsWritable();
+    adjacencyList.readFields(in);
   }
 
   /**
@@ -114,13 +114,13 @@ public class BfsNode implements Writable {
       out.writeInt(distance);
     }
 
-    adjacenyList.write(out);
+    adjacencyList.write(out);
   }
 
   @Override
   public String toString() {
-    return String.format("{%d %d %s}", nodeid, distance, (adjacenyList == null ? "[]"
-        : adjacenyList.toString(10)));
+    return String.format("{%d %d %s}", nodeid, distance, (adjacencyList == null ? "[]"
+        : adjacencyList.toString(10)));
   }
 
   /**

--- a/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankMessages.java
+++ b/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankMessages.java
@@ -1,0 +1,8 @@
+package io.bespin.java.mapreduce.pagerank;
+
+/**
+ * Publicly accessible enum of message types shared across PageRank implementations
+ */
+public enum PageRankMessages {
+    nodes, edges, massMessages, massMessagesSaved, massMessagesReceived, missingStructure
+}

--- a/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankNode.java
+++ b/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankNode.java
@@ -36,7 +36,7 @@ public class PageRankNode implements Writable {
   private Type type;
   private int nodeid;
   private float pagerank;
-  private ArrayListOfIntsWritable adjacenyList;
+  private ArrayListOfIntsWritable adjacencyList;
 
   public PageRankNode() {}
 
@@ -56,12 +56,12 @@ public class PageRankNode implements Writable {
     this.nodeid = n;
   }
 
-  public ArrayListOfIntsWritable getAdjacenyList() {
-    return adjacenyList;
+  public ArrayListOfIntsWritable getAdjacencyList() {
+    return adjacencyList;
   }
 
   public void setAdjacencyList(ArrayListOfIntsWritable list) {
-    this.adjacenyList = list;
+    this.adjacencyList = list;
   }
 
   public Type getType() {
@@ -92,8 +92,8 @@ public class PageRankNode implements Writable {
       pagerank = in.readFloat();
     }
 
-    adjacenyList = new ArrayListOfIntsWritable();
-    adjacenyList.readFields(in);
+    adjacencyList = new ArrayListOfIntsWritable();
+    adjacencyList.readFields(in);
   }
 
   /**
@@ -115,13 +115,13 @@ public class PageRankNode implements Writable {
       out.writeFloat(pagerank);
     }
 
-    adjacenyList.write(out);
+    adjacencyList.write(out);
   }
 
   @Override
   public String toString() {
-    return String.format("{%d %.4f %s}", nodeid, pagerank, (adjacenyList == null ? "[]"
-        : adjacenyList.toString(10)));
+    return String.format("{%d %.4f %s}", nodeid, pagerank, (adjacencyList == null ? "[]"
+        : adjacencyList.toString(10)));
   }
 
   /**

--- a/src/main/java/io/bespin/java/mapreduce/search/BooleanRetrieval.java
+++ b/src/main/java/io/bespin/java/mapreduce/search/BooleanRetrieval.java
@@ -31,7 +31,7 @@ public class BooleanRetrieval extends Configured implements Tool {
   private FSDataInputStream collection;
   private Stack<Set<Integer>> stack;
 
-  private BooleanRetrieval() {}
+  public BooleanRetrieval() {}
 
   private void initialize(String indexPath, String collectionPath, FileSystem fs) throws IOException {
     index = new MapFile.Reader(new Path(indexPath + "/part-r-00000"), fs.getConf());

--- a/src/main/java/io/bespin/java/mapreduce/search/BuildInvertedIndex.java
+++ b/src/main/java/io/bespin/java/mapreduce/search/BuildInvertedIndex.java
@@ -95,7 +95,7 @@ public class BuildInvertedIndex extends Configured implements Tool {
     }
   }
 
-  private BuildInvertedIndex() {}
+  public BuildInvertedIndex() {}
 
   public static class Args {
     @Option(name = "-input", metaVar = "[path]", required = true, usage = "input path")

--- a/src/main/scala/io/bespin/scala/mapreduce/bfs/EncodeBfsGraph.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bfs/EncodeBfsGraph.scala
@@ -1,0 +1,80 @@
+package io.bespin.scala.mapreduce.bfs
+
+import io.bespin.java.mapreduce.bfs.BfsNode
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper}
+import org.apache.hadoop.io.{IntWritable, LongWritable, Text}
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListOfIntsWritable
+
+/**
+  * Tool for taking a plain-text encoding of a directed graph and building corresponding Hadoop
+  * structures for running parallel breadth-first search.
+  */
+object EncodeBfsGraph extends BaseConfiguredTool with MapReduceSugar {
+  private val SRC_KEY = "src"
+  private val COUNTERS = "Counters"
+  private val NODES = "Nodes"
+  private val EDGES = "Edges"
+
+  private object MyMapper extends TypedMapper[LongWritable, Text, IntWritable, BfsNode] {
+    private var src: Int = _
+    private val node = new BfsNode
+    private val nid = new IntWritable()
+
+    override def setup(context: Context): Unit = {
+      src = context.getConfiguration.getInt(SRC_KEY, 0)
+      node.setType(BfsNode.Type.Complete)
+    }
+
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val arr = value.toString.trim.split("\\s+")
+
+      val ints = arr.map(_.toInt)
+      val cur = ints.head
+
+      nid.set(cur)
+      node.setNodeId(cur)
+      node.setDistance(if(cur == src) 0 else Int.MaxValue)
+
+      node.setAdjacencyList(new ArrayListOfIntsWritable(ints.tail))
+
+      context.getCounter(COUNTERS, NODES).increment(1)
+      context.getCounter(COUNTERS, EDGES).increment(arr.length - 1)
+
+      context.write(nid, node)
+    }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val src = opt[Int](descr = "src", required = true)
+
+    mainOptions = Seq(input, output, src)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: " + this.getClass.getName)
+    log.info(" - inputDir: " + args.input())
+    log.info(" - outputDir: " + args.output())
+    log.info(" - src: " + args.src())
+
+    val conf = getConf
+    conf.setInt(SRC_KEY, args.src())
+    conf.setInt("mapred.min.split.size", 1024 * 1024 * 1024)
+
+    val thisJob =
+      job(s"EncodeBfsGraph[input: ${args.input()}, output: ${args.output()}, src: ${args.src()}", conf)
+        .textFile(args.input())
+        .map(MyMapper)
+        .reduce(0)
+
+    time {
+      thisJob.saveAsSequenceFile(args.output(), deleteExisting = true)
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bfs/FindNodeAtDistance.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bfs/FindNodeAtDistance.scala
@@ -1,0 +1,59 @@
+package io.bespin.scala.mapreduce.bfs
+
+import io.bespin.java.mapreduce.bfs.BfsNode
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper}
+import org.apache.hadoop.io.IntWritable
+import org.rogach.scallop.ScallopConf
+
+/**
+  * Tool for extracting nodes that are a particular distance from the source node.
+  */
+object FindNodeAtDistance extends BaseConfiguredTool with MapReduceSugar {
+
+  private val Distance_Key = "distance"
+
+  private object MyMapper extends TypedMapper[IntWritable, BfsNode, IntWritable, BfsNode] {
+    private[this] var distance: Int = _
+
+    override def setup(context: Context): Unit = {
+      distance = context.getConfiguration.getInt(Distance_Key, 0)
+    }
+
+    override def map(nid: IntWritable, node: BfsNode, context: Context): Unit = {
+      if(node.getDistance == distance) {
+        context.write(nid, node)
+      }
+    }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val distance = opt[Int](descr = "distance", required = true)
+
+    mainOptions = Seq(input, output, distance)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: " + this.getClass.getName)
+    log.info(" - inputDir: " + args.input())
+    log.info(" - outputDir: " + args.output())
+    log.info(" - distance: " + args.distance())
+
+    val conf = getConf
+    conf.setInt(Distance_Key, args.distance())
+    conf.setInt("mapred.min.split.size", 1024 * 1024 * 1024)
+
+    val thisJob = job(s"FindNodeAtDistance[input: ${args.input()}, " +
+      s"output: ${args.output()}, distance: ${args.distance()}]", conf)
+      .sequenceFile[IntWritable, BfsNode](args.input())
+      .map(MyMapper)
+      .reduce(0)
+
+    thisJob.saveAsTextFile(args.output(), deleteExisting = true)
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bfs/FindReachableNodes.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bfs/FindReachableNodes.scala
@@ -1,0 +1,50 @@
+package io.bespin.scala.mapreduce.bfs
+
+import io.bespin.java.mapreduce.bfs.BfsNode
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper}
+import org.apache.hadoop.io.IntWritable
+import org.rogach.scallop.ScallopConf
+
+/**
+  * Tool for extracting nodes that are reachable from the source node.
+  */
+object FindReachableNodes extends BaseConfiguredTool with MapReduceSugar {
+
+  // Very simple mapper which essentially just filters out all nodes which have
+  // "infinite" distance
+  private object MyMapper extends TypedMapper[IntWritable, BfsNode, IntWritable, BfsNode] {
+    override def map(nid: IntWritable, node: BfsNode, context: Context): Unit = {
+      if(node.getDistance < Int.MaxValue) {
+        context.write(nid, node)
+      }
+    }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+
+    mainOptions = Seq(input, output)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: " + this.getClass.getName)
+    log.info(" - inputDir: " + args.input())
+    log.info(" - outputDir: " + args.output())
+
+    val conf = getConf
+    conf.setInt("mapred.min.split.size", 1024 * 1024 * 1024)
+
+    val thisJob = job(s"FindReachableNodes:[input: ${args.input()}, " +
+      s"output: ${args.output()}]", conf)
+      .sequenceFile[IntWritable, BfsNode](args.input())
+      .map(MyMapper)
+      .reduce(0)
+
+    thisJob.saveAsTextFile(args.output(), deleteExisting = true)
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bfs/IterateBfs.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bfs/IterateBfs.scala
@@ -1,0 +1,156 @@
+package io.bespin.scala.mapreduce.bfs
+
+import io.bespin.java.mapreduce.bfs.BfsNode
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import org.apache.hadoop.io.IntWritable
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListOfIntsWritable
+import tl.lin.data.map.HMapII
+
+import scala.collection.JavaConverters._
+
+/**
+  * Tool for running one iteration of parallel breadth-first search.
+  */
+object IterateBfs extends BaseConfiguredTool with MapReduceSugar {
+  private val Counter = "Counter"
+  private val ReachableInMapper = "ReachableInMapper"
+  private val ReachableInReducer = "ReachableInReducer"
+
+  private object MapClass extends TypedMapper[IntWritable, BfsNode, IntWritable, BfsNode] {
+    // For buffering distances keyed by destination node.
+    private[this] val map = new HMapII
+
+    // For passing along node structure.
+    private[this] val intermediateStructure = new BfsNode
+
+    override def setup(context: Context): Unit = {
+      // Must clear the map for cases where mapper is
+      // re-used (such as for local execution)
+      map.clear()
+    }
+
+    override def map(nid: IntWritable, node: BfsNode, context: Context): Unit = {
+      // Pass along node structure.
+      intermediateStructure.setNodeId(node.getNodeId)
+      intermediateStructure.setType(BfsNode.Type.Structure)
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList)
+
+      context.write(nid, intermediateStructure)
+
+      if(node.getDistance != Int.MaxValue) {
+        context.getCounter(Counter, ReachableInMapper).increment(1)
+        // Retain distance to self.
+        map.put(nid.get, node.getDistance)
+
+        val adj = node.getAdjacencyList
+        val dist = node.getDistance + 1
+        // Keep track of distance if it's shorter than previously
+        // encountered, or if we haven't encountered this node.
+        // Note that putting this into a more scala-idiomatic "foreach" seems
+        // to cause it to silently skip nodes in some cases, so a while loop
+        // is used instead.
+        var i = 0
+        while(i < adj.size) {
+          val neighbor = adj.get(i)
+          if(!map.containsKey(neighbor) || dist < map.get(neighbor)) {
+            map.put(neighbor, dist)
+          }
+          i += 1
+        }
+      }
+    }
+
+    override def cleanup(context: Context): Unit = {
+      val k = new IntWritable
+      val dist = new BfsNode
+      for (e <- map.entrySet.asScala) {
+        k.set(e.getKey)
+        dist.setNodeId(e.getKey)
+        dist.setType(BfsNode.Type.Distance)
+        dist.setDistance(e.getValue)
+        context.write(k, dist)
+      }
+    }
+  }
+
+  private object ReduceClass extends TypedReducer[IntWritable, BfsNode, IntWritable, BfsNode] {
+    private[this] val node = new BfsNode
+
+    override def reduce(nid: IntWritable, iterable: Iterable[BfsNode], context: Context): Unit = {
+      val values = iterable.iterator
+
+      var structureReceived: Int = 0
+      var dist: Int = Int.MaxValue
+
+      while(values.hasNext) {
+        val n = values.next
+
+        if(n.getType == BfsNode.Type.Structure) {
+          // This is the structure node; update accordingly
+          node.setAdjacencyList(new ArrayListOfIntsWritable(n.getAdjacencyList))
+          structureReceived += 1
+        } else {
+          // This is a message that contains distance
+          dist = math.min(dist, n.getDistance)
+        }
+      }
+
+      node.setType(BfsNode.Type.Complete)
+      node.setNodeId(nid.get)
+      node.setDistance(dist) // Update the final distance
+
+      if(dist != Int.MaxValue) {
+        context.getCounter(Counter, ReachableInReducer).increment(1)
+      }
+
+      // Error checking
+      if(structureReceived == 1) {
+        // Everything checks out, emit final node structures with updated distance.
+        context.write(nid, node)
+      } else if(structureReceived == 0) {
+        // We get into this situation if there exists an edge pointing
+        // to a node which has no corresponding node structure (i.e.,
+        // distance was passed to a non-existent node)... log but move
+        // on.
+        log.warn("No structure received for nodeid: " + nid.get)
+      } else {
+        // This should never happen
+        throw new RuntimeException("Multiple structure received for nodeid: " + nid.get
+          + " struct: " + structureReceived)
+      }
+    }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val partitions = opt[Int](descr = "number of partitions", required = true)
+
+    mainOptions = Seq(input, output, partitions)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: " + this.getClass.getSimpleName)
+    log.info(" - input: " + args.input())
+    log.info(" - output: " + args.output())
+    log.info(" - partitions:" + args.partitions())
+
+    val conf = getConf
+    conf.set("mapred.child.java.opts", "-Xmx2048m")
+
+    val thisJob = job(s"IterateBfs[input: ${args.input()}, output: ${args.output()}, " +
+      s"partitions: ${args.partitions()}", conf)
+      .sequenceFile[IntWritable, BfsNode](args.input())
+      .map(MapClass)
+      .reduce(ReduceClass, args.partitions())
+
+    time {
+      thisJob.saveAsSequenceFile(args.output(), deleteExisting = true)
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bigram/ComputeBigramRelativeFrequencyPairs.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bigram/ComputeBigramRelativeFrequencyPairs.scala
@@ -1,0 +1,86 @@
+package io.bespin.scala.mapreduce.bigram
+
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import io.bespin.scala.util.Tokenizer
+import org.apache.hadoop.io.{FloatWritable, LongWritable, Text}
+import org.apache.hadoop.mapreduce.Partitioner
+import tl.lin.data.pair.PairOfStrings
+
+object ComputeBigramRelativeFrequencyPairs extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
+
+  private val wildcard: String = "*"
+  private val one: FloatWritable = 1.0f
+
+  private object PairsMapper extends TypedMapper[LongWritable, Text, PairOfStrings, FloatWritable] {
+
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val tokens = tokenize(value)
+      if(tokens.length >= 2) {
+        tokens.iterator.zip(tokens.tail.iterator).foreach {
+          case (left, right) =>
+            context.write((left, right), one)
+            context.write((left, wildcard), one)
+        }}
+
+    }
+  }
+
+  /**
+    * Combiner object for pairs. Simply sums up the count of all (pair, count) keys sharing the same pair.
+    */
+  private object PairsCombiner extends TypedReducer[PairOfStrings, FloatWritable, PairOfStrings, FloatWritable] {
+    override def reduce(key: PairOfStrings, values: Iterable[FloatWritable], context: Context): Unit = {
+      context.write(key, values.foldLeft(0.0f)(_ + _))
+    }
+  }
+
+  private object PairsReducer extends TypedReducer[PairOfStrings, FloatWritable, PairOfStrings, FloatWritable] {
+    private var marginal: Float = _
+
+    override def reduce(key: PairOfStrings, values: Iterable[FloatWritable], context: Context): Unit = {
+
+      val sum = values.foldLeft(0.0f)(_ + _)
+
+      if(key.getRightElement == wildcard) {
+        context.write(key, sum)
+        marginal = sum
+      } else {
+        context.write(key, sum / marginal)
+      }
+    }
+  }
+
+  private object PairsPartitioner extends Partitioner[PairOfStrings, FloatWritable] {
+    override def getPartition(key: PairOfStrings, value: FloatWritable, numPartitions: Int): Int =
+      (key.getLeftElement.hashCode & Int.MaxValue) % numPartitions
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new ConfWithOutput(argv)
+
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+    log.info("Number of reducers: " + args.reducers())
+    log.info("Text output: " + args.textOutput())
+
+    val thisJob =
+      job("Bigram Relative Frequency - Pairs", getConf)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(PairsMapper)
+        .combine(PairsCombiner)
+        .partition(PairsPartitioner)
+        .reduce(PairsReducer, args.reducers())
+
+    time {
+      if (args.textOutput())
+        thisJob.saveAsTextFile(args.output())
+      else
+        thisJob.saveAsSequenceFile(args.output())
+    }
+
+    0
+  }
+
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bigram/ComputeBigramRelativeFrequencyStripes.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bigram/ComputeBigramRelativeFrequencyStripes.scala
@@ -1,0 +1,76 @@
+package io.bespin.scala.mapreduce.bigram
+
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import io.bespin.scala.util.Tokenizer
+import org.apache.hadoop.io.{LongWritable, Text}
+import tl.lin.data.map.HMapStFW
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object ComputeBigramRelativeFrequencyStripes extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
+
+  private object StripesMapper extends TypedMapper[LongWritable, Text, Text, HMapStFW] {
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val tokens = tokenize(value)
+      val stripes: mutable.Map[String, HMapStFW] = mutable.HashMap()
+      if(tokens.length >= 2) {
+        tokens.iterator.zip(tokens.tail.iterator).foreach {
+          case (prev, cur) =>
+            val stripe = stripes.getOrElseUpdate(prev, new HMapStFW)
+            stripe.increment(cur)
+        }
+        stripes.foreach { case (k, stripe) => context.write(k, stripe) }
+      }
+    }
+  }
+
+  private object StripesCombiner extends TypedReducer[Text, HMapStFW, Text, HMapStFW] {
+    override def reduce(key: Text, values: Iterable[HMapStFW], context: Context): Unit = {
+      val newMap = new HMapStFW
+      values.foreach(v => newMap.plus(v))
+      context.write(key, newMap)
+    }
+  }
+
+  private object StripesReducer extends TypedReducer[Text, HMapStFW, Text, HMapStFW] {
+    override def reduce(key: Text, values: Iterable[HMapStFW], context: Context): Unit = {
+      val finalMap: HMapStFW = new HMapStFW
+      values.foreach(v => finalMap.plus(v))
+
+      val sum = finalMap.values.foldLeft(0.0f)(_ + _)
+
+      finalMap.entrySet().foreach(entry =>
+        finalMap.put(entry.getKey, entry.getValue / sum))
+
+      context.write(key, finalMap)
+    }
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new ConfWithOutput(argv)
+
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+    log.info("Number of reducers: " + args.reducers())
+    log.info("Text output: " + args.textOutput())
+
+    val thisJob =
+      job("Bigram Relative Frequency - Stripes", getConf)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(StripesMapper)
+        .combine(StripesCombiner)
+        .reduce(StripesReducer, args.reducers())
+
+    time {
+      if (args.textOutput())
+        thisJob.saveAsTextFile(args.output())
+      else
+        thisJob.saveAsSequenceFile(args.output())
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/bigram/Conf.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/bigram/Conf.scala
@@ -1,0 +1,20 @@
+package io.bespin.scala.mapreduce.bigram
+
+import org.rogach.scallop.ScallopConf
+
+class Conf(args: Seq[String]) extends ScallopConf(args) {
+  lazy val input = opt[String](descr = "input path", required = true)
+  lazy val output = opt[String](descr = "output path", required = true)
+  lazy val reducers = opt[Int](descr = "number of reducers", required = false, default = Some(1))
+
+  mainOptions = Seq(input, output, reducers)
+}
+
+class ConfWithOutput(args: Seq[String]) extends ScallopConf(args) {
+  lazy val input = opt[String](descr = "input path", required = true)
+  lazy val output = opt[String](descr = "output path", required = true)
+  lazy val reducers = opt[Int](descr = "number of reducers", required = false, default = Some(1))
+  lazy val textOutput = toggle("textOutput", default = Some(false),
+    descrYes = "Use TextOutputFormat", descrNo = "Use SequenceFileOutputFormat")
+  mainOptions = Seq(input, output, reducers, textOutput)
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/cooccur/ComputeCooccurrenceMatrixPairs.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/cooccur/ComputeCooccurrenceMatrixPairs.scala
@@ -1,0 +1,82 @@
+package io.bespin.scala.mapreduce.cooccur
+
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import io.bespin.scala.util.Tokenizer
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.{IntWritable, LongWritable, Text}
+import org.apache.hadoop.mapreduce.Partitioner
+import tl.lin.data.pair.PairOfStrings
+
+/**
+  * Implementation of the "pairs" algorithm for computing co-occurrence matrices from a large text
+  * collection. This algorithm is described in Chapter 3 of "Data-Intensive Text Processing with
+  * MapReduce" by Lin &amp; Dyer, as well as the following paper:
+  *
+  * <blockquote>Jimmy Lin. <b>Scalable Language Processing Algorithms for the Masses: A Case Study in
+  * Computing Word Co-occurrence Matrices with MapReduce.</b> <i>Proceedings of the 2008 Conference
+  * on Empirical Methods in Natural Language Processing (EMNLP 2008)</i>, pages 419-428.</blockquote>
+  *
+  * @see [[io.bespin.java.mapreduce.cooccur.ComputeCooccurrenceMatrixPairs]]
+  */
+object ComputeCooccurrenceMatrixPairs extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
+
+  private object MyMapper extends TypedMapper[LongWritable, Text, PairOfStrings, IntWritable] {
+    private var windowSize: Int = _
+
+    override def setup(context: Context): Unit = {
+      windowSize = context.getConfiguration.getInt("window", 2)
+    }
+
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val tokens = tokenize(value).toArray
+      tokens.zipWithIndex.foreach { case (token, i) =>
+        val start = Math.max(i - windowSize, 0)
+        val end = Math.min(i + windowSize + 1, tokens.length)
+        (start until end).foreach { j =>
+          if(i != j)
+            context.write((token, tokens(j)), 1)
+        }
+      }
+    }
+
+  }
+
+  private object MyReducer extends TypedReducer[PairOfStrings, IntWritable, PairOfStrings, IntWritable] {
+    override def reduce(key: PairOfStrings, values: Iterable[IntWritable], context: Context): Unit = {
+      context.write(key, values.foldLeft(0)(_ + _))
+    }
+  }
+
+  private object MyPartitioner extends Partitioner[PairOfStrings, IntWritable] {
+    override def getPartition(key: PairOfStrings, value: IntWritable, numPartitions: Int): Int =
+      (key.getLeftElement.hashCode & Int.MaxValue) % numPartitions
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+    log.info("Window: " + args.window())
+    log.info("Number of reducers: " + args.reducers())
+
+    val config = getConf
+    config.setInt("window", args.window())
+
+    val thisJob =
+      job("Cooccurrence Matrix - Pairs", config)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(MyMapper)
+        .combine(MyReducer)
+        .partition(MyPartitioner)
+        .reduce(MyReducer, args.reducers())
+
+    time {
+      thisJob.saveAsTextFile(args.output())
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/cooccur/ComputeCooccurrenceMatrixStripes.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/cooccur/ComputeCooccurrenceMatrixStripes.scala
@@ -1,0 +1,83 @@
+package io.bespin.scala.mapreduce.cooccur
+
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import io.bespin.scala.util.Tokenizer
+import org.apache.hadoop.io.{LongWritable, Text}
+import tl.lin.data.map.HMapStIW
+
+/**
+  * Implementation of the "stripes" algorithm for computing co-occurrence matrices from a large text
+  * collection. This algorithm is described in Chapter 3 of "Data-Intensive Text Processing with
+  * MapReduce" by Lin &amp; Dyer, as well as the following paper:
+  *
+  * <blockquote>Jimmy Lin. <b>Scalable Language Processing Algorithms for the Masses: A Case Study in
+  * Computing Word Co-occurrence Matrices with MapReduce.</b> <i>Proceedings of the 2008 Conference
+  * on Empirical Methods in Natural Language Processing (EMNLP 2008)</i>, pages 419-428.</blockquote>
+  *
+  * @see [[io.bespin.java.mapreduce.cooccur.ComputeCooccurrenceMatrixStripes]]
+  */
+object ComputeCooccurrenceMatrixStripes extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
+
+  private object MyMapper extends TypedMapper[LongWritable, Text, Text, HMapStIW] {
+    private var windowSize: Int = _
+    private val map: HMapStIW = new HMapStIW
+
+    override def setup(context: Context): Unit = {
+      windowSize = context.getConfiguration.getInt("window", 2)
+    }
+
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val tokens = tokenize(value).toArray
+
+      tokens.zipWithIndex.foreach { case (token, i) =>
+        map.clear()
+        val start = Math.max(i - windowSize, 0)
+        val end = Math.min(i + windowSize + 1, tokens.length)
+        (start until end).foreach { j =>
+          if(i != j)
+            map.increment(tokens(j))
+        }
+        context.write(token, map)
+      }
+    }
+
+  }
+
+  private object MyReducer extends TypedReducer[Text, HMapStIW, Text, HMapStIW] {
+
+    override def reduce(key: Text, values: Iterable[HMapStIW], context: Context): Unit = {
+      val map = new HMapStIW
+      values.foreach { map.plus }
+      context.write(key, map)
+    }
+
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+    log.info("Window: " + args.window())
+    log.info("Number of reducers: " + args.reducers())
+
+    val config = getConf
+    config.setInt("window", args.window())
+
+    val thisJob =
+      job("Cooccurrence Matrix - Stripes", config)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(MyMapper)
+        .combine(MyReducer)
+        .reduce(MyReducer, args.reducers())
+
+    time {
+      thisJob.saveAsTextFile(args.output())
+    }
+
+    0
+  }
+
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/cooccur/Conf.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/cooccur/Conf.scala
@@ -1,0 +1,12 @@
+package io.bespin.scala.mapreduce.cooccur
+
+import org.rogach.scallop.ScallopConf
+
+class Conf(args: Seq[String]) extends ScallopConf(args) {
+  lazy val input = opt[String](descr = "input path", required = true)
+  lazy val output = opt[String](descr = "output path", required = true)
+  lazy val reducers = opt[Int](descr = "number of reducers", required = false, default = Some(1))
+  lazy val window = opt[Int](descr = "cooccurrence window", required = false, default = Some(2))
+
+  mainOptions = Seq(input, output, reducers, window)
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/pagerank/BuildPageRankRecords.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/pagerank/BuildPageRankRecords.scala
@@ -1,0 +1,93 @@
+package io.bespin.scala.mapreduce.pagerank
+
+import io.bespin.java.mapreduce.pagerank.PageRankNode
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper}
+import org.apache.hadoop.io.{IntWritable, LongWritable, Text}
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListOfIntsWritable
+
+
+/**
+  * <p>
+  * Driver program that takes a plain-text encoding of a directed graph and builds corresponding
+  * Hadoop structures for representing the graph.
+  * </p>
+  */
+object BuildPageRankRecords extends BaseConfiguredTool with MapReduceSugar {
+
+  private val NODE_CNT_FIELD: String = "node.cnt"
+
+  private val GRAPH_QUAL: String = "graph"
+  private val NUM_NODES: String = "numNodes"
+  private val NUM_EDGES: String = "numEdges"
+  private val NUM_ACTIVE_NODES: String = "numActiveNodes"
+
+  private object MyMapper extends TypedMapper[LongWritable, Text, IntWritable, PageRankNode] {
+    private val nid: IntWritable = new IntWritable()
+    private val node: PageRankNode = new PageRankNode()
+
+    override def setup(context: Context): Unit = {
+      val n = context.getConfiguration.getInt(NODE_CNT_FIELD, 0)
+      if(n == 0)
+        throw new RuntimeException(s"$NODE_CNT_FIELD must be set to non-zero value!")
+      node.setType(PageRankNode.Type.Complete)
+      node.setPageRank(-StrictMath.log(n).toFloat)
+    }
+
+
+    override def map(key: LongWritable, value: Text, context: Context): Unit = {
+      val arr: Array[Int] = value.toString.trim.split("\\s+").map(_.toInt)
+
+      val nodeId = arr(0)
+      nid.set(nodeId)
+      node.setNodeId(nodeId)
+
+      if(arr.length == 1) {
+        node.setAdjacencyList(new ArrayListOfIntsWritable())
+      } else {
+        val neighbors: Array[Int] = arr.tail
+        node.setAdjacencyList(new ArrayListOfIntsWritable(neighbors))
+      }
+
+      context.getCounter(GRAPH_QUAL, NUM_NODES).increment(1)
+      context.getCounter(GRAPH_QUAL, NUM_EDGES).increment(arr.length - 1)
+
+      if(arr.length > 1)
+        context.getCounter(GRAPH_QUAL, NUM_ACTIVE_NODES).increment(1)
+
+      context.write(nid, node)
+    }
+
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val numNodes = opt[Int](descr = "number of nodes", required = true)
+
+    mainOptions = Seq(input, output, numNodes)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info(s"Tool name: ${BuildPageRankRecords.getClass.getSimpleName}")
+    log.info(s" - inputDir: ${args.input()}")
+    log.info(s" - outputDir: ${args.output()}")
+    log.info(s" - numNodes: ${args.numNodes()}")
+
+    val conf = getConf
+    conf.setInt(NODE_CNT_FIELD, args.numNodes())
+    conf.setInt("mapred.min.split.size", 1024 * 1024 * 1024)
+
+    val thisJob =
+      job(this.getClass.getSimpleName + ":" + args.input(), conf)
+        .textFile(args.input())
+        .map(MyMapper)
+        .reduce(0)
+
+    thisJob.saveAsSequenceFile(args.output(), deleteExisting = true)
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/pagerank/PartitionGraph.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/pagerank/PartitionGraph.scala
@@ -1,0 +1,63 @@
+package io.bespin.scala.mapreduce.pagerank
+
+import io.bespin.java.mapreduce.pagerank.{NonSplitableSequenceFileInputFormat, PageRankNode}
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar}
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.IntWritable
+import org.rogach.scallop.ScallopConf
+
+/**
+  * <p>
+  * Driver program for partitioning the graph.
+  * </p>
+  */
+object PartitionGraph extends BaseConfiguredTool with MapReduceSugar {
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val numNodes = opt[Int](descr = "number of nodes", required = true)
+    lazy val numPartitions = opt[Int](descr = "number of partitions", required = true)
+    lazy val range = opt[Boolean](descr = "use range partitioner", required = false, default = Some(false))
+
+    mainOptions = Seq(input, output, numNodes, numPartitions, range)
+  }
+
+  /**
+    * Create an instance of the RangePartitioner class for PageRankNodes
+    */
+  object ThisRangePartitioner extends RangePartitioner[PageRankNode]
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: " + PartitionGraph.getClass.getSimpleName)
+    log.info(" - input dir: " + args.input())
+    log.info(" - output dir: " + args.output())
+    log.info(" - num partitions: " + args.numPartitions())
+    log.info(" - node cnt: " + args.numNodes())
+    log.info(" - use range partitioner: " + args.range())
+
+    val conf = getConf
+    conf.setInt("NodeCount", args.numNodes())
+
+    val input =
+      job(PartitionGraph.getClass.getSimpleName + ":" + args.input(), conf)
+        .file(new Path(args.input()), classOf[NonSplitableSequenceFileInputFormat[IntWritable, PageRankNode]])
+
+    val partitionedJob =
+      if(args.range()) {
+        input.partition(ThisRangePartitioner)
+      } else {
+        input
+      }
+
+    val reducedJob = partitionedJob.reduce(args.numPartitions())
+
+    time {
+      reducedJob.saveAsSequenceFile(new Path(args.output()), deleteExisting = true)
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/pagerank/RangePartitioner.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/pagerank/RangePartitioner.scala
@@ -1,0 +1,28 @@
+package io.bespin.scala.mapreduce.pagerank
+
+import org.apache.hadoop.conf.{Configurable, Configuration}
+import org.apache.hadoop.io.{IntWritable, Writable}
+import org.apache.hadoop.mapreduce.Partitioner
+
+
+class RangePartitioner[T <: Writable] extends Partitioner[IntWritable, T] with Configurable {
+  private var nodeCnt: Int = 0
+  private var conf: Configuration = null
+
+  def getPartition(key: IntWritable, value: T, numReduceTasks: Int): Int = {
+    ((key.get.toFloat / nodeCnt.toFloat) * numReduceTasks).toInt % numReduceTasks
+  }
+
+  def getConf: Configuration = {
+    conf
+  }
+
+  def setConf(conf: Configuration): Unit = {
+    this.conf = conf
+    configure()
+  }
+
+  private def configure(): Unit = {
+    nodeCnt = conf.getInt("NodeCount", 0)
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/pagerank/RunPageRankBasic.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/pagerank/RunPageRankBasic.scala
@@ -1,0 +1,427 @@
+package io.bespin.scala.mapreduce.pagerank
+
+import java.text.{DecimalFormat, NumberFormat}
+
+import com.google.common.base.Preconditions
+import io.bespin.java.mapreduce.pagerank.{NonSplitableSequenceFileInputFormat, PageRankMessages, PageRankNode}
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
+import org.apache.hadoop.io.IntWritable
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.map.HMapIF
+
+import scala.collection.JavaConverters._
+
+/**
+  * <p>
+  * Main driver program for running the basic (non-Schimmy) implementation of
+  * PageRank.
+  * </p>
+  *
+  * <p>
+  * The starting and ending iterations will correspond to paths
+  * <code>/base/path/iterXXXX</code> and <code>/base/path/iterYYYY</code>. As a
+  * example, if you specify 0 and 10 as the starting and ending iterations, the
+  * driver program will start with the graph structure stored at
+  * <code>/base/path/iter0000</code>; final results will be stored at
+  * <code>/base/path/iter0010</code>.
+  * </p>
+  *
+  * @see [[RunPageRankSchimmy]]
+  */
+object RunPageRankBasic extends BaseConfiguredTool with MapReduceSugar {
+
+  private object MapClass extends TypedMapper[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+
+    // The neighbor to which we're sending messages.
+    private[this] val neighbor = new IntWritable
+
+    // Contents of the messages: partial PageRank mass.
+    private[this] val intermediateMass = new PageRankNode
+
+    // For passing along node structure.
+    private[this] val intermediateStructure = new PageRankNode
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      // Pass along node structure
+      intermediateStructure.setNodeId(node.getNodeId)
+      intermediateStructure.setType(PageRankNode.Type.Structure)
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList)
+
+      context.write(nid, intermediateStructure)
+
+      val massMessages = node.getAdjacencyList.size
+
+      // Distribute PageRank mass to neighbors (along outgoing edges).
+      if(massMessages > 0) {
+        // Each neighbor gets an equal share of PageRank mass.
+        val list = node.getAdjacencyList
+        val mass = node.getPageRank - StrictMath.log(list.size()).toFloat
+
+        context.getCounter(PageRankMessages.edges).increment(list.size)
+
+        var i: Int = 0
+        while(i < list.size()) {
+          val nextNeighbor = list.get(i)
+          neighbor.set(nextNeighbor)
+          intermediateMass.setNodeId(nextNeighbor)
+          intermediateMass.setType(PageRankNode.Type.Mass)
+          intermediateMass.setPageRank(mass)
+
+          // Emit messages with PageRank mass to neighbors.
+          context.write(neighbor, intermediateMass)
+          i += 1
+        }
+      }
+
+      // Bookkeeping.
+      context.getCounter(PageRankMessages.nodes).increment(1)
+      context.getCounter(PageRankMessages.massMessages).increment(massMessages)
+    }
+  }
+
+  private object MapWithInMapperCombiningClass extends TypedMapper[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+    // For buffering PageRank mass contributions keyed by destination node
+    private[this] val map = new HMapIF
+
+    // For passing along node structure.
+    private val intermediateStructure = new PageRankNode
+
+    override def setup(context: Context): Unit = {
+      // When running in local mode, the mappers are re-used and must be re-set. This is not
+      // necessarily required in distributed mode.
+      map.clear()
+    }
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      // Pass along node structure
+      intermediateStructure.setNodeId(node.getNodeId)
+      intermediateStructure.setType(PageRankNode.Type.Structure)
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList)
+
+      context.write(nid, intermediateStructure)
+
+      // Variables for bookkeeping
+      var massMessages = 0
+      var massMessagesSaved = 0
+
+      // Distribute PageRank mass to neighbors (along outgoing edges).
+      if(node.getAdjacencyList.size > 0) {
+        // Each neighbor gets an equal share of PageRank mass.
+        val list = node.getAdjacencyList
+        val mass = node.getPageRank - StrictMath.log(list.size()).toFloat
+
+        context.getCounter(PageRankMessages.edges).increment(list.size())
+
+        var i = 0
+        while(i < list.size) {
+          val nextNeighbor = list.get(i)
+          if(map.containsKey(nextNeighbor)) {
+            // Already message destined for that node; add PageRank mass contribution.
+            massMessagesSaved += 1
+            map.put(nextNeighbor, sumLogProbs(map.get(nextNeighbor), mass))
+          } else {
+            // New destination node; add new entry in map.
+            massMessages += 1
+            map.put(nextNeighbor, mass)
+          }
+          i += 1
+        }
+      }
+      // Bookkeeping.
+      context.getCounter(PageRankMessages.nodes).increment(1)
+      context.getCounter(PageRankMessages.massMessages).increment(massMessages)
+      context.getCounter(PageRankMessages.massMessagesSaved).increment(massMessagesSaved)
+    }
+
+    override def cleanup(context: Context): Unit = {
+      // Now emit all messages for this node at once.
+      val k = new IntWritable
+      val mass = new PageRankNode
+
+      for(e <- map.entrySet.asScala) {
+        k.set(e.getKey)
+
+        mass.setNodeId(e.getKey)
+        mass.setType(PageRankNode.Type.Mass)
+        mass.setPageRank(e.getValue)
+
+        context.write(k, mass)
+      }
+    }
+  }
+
+  private object CombineClass extends TypedReducer[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+    private[this] val intermediateMass = new PageRankNode
+
+    override def reduce(nid: IntWritable, values: Iterable[PageRankNode], context: Context): Unit = {
+
+      val (massMessages, mass) = values.foldLeft((0, Float.NegativeInfinity)) {
+        case ((messages, massSum), n) =>
+        if(n.getType == PageRankNode.Type.Structure) {
+          // Simply pass along node structure.
+          context.write(nid, n)
+          (messages, massSum)
+        } else {
+          // Accumulate PageRank mass contributions
+          (messages + 1, sumLogProbs(massSum, n.getPageRank))
+        }
+      }
+
+      // Emit aggregated results
+      if(massMessages > 0) {
+        intermediateMass.setNodeId(nid.get())
+        intermediateMass.setType(PageRankNode.Type.Mass)
+        intermediateMass.setPageRank(mass)
+
+        context.write(nid, intermediateMass)
+      }
+    }
+  }
+
+  private object ReduceClass extends
+    TypedReducer[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+    // For keeping track of PageRank mass encountered, so we can compute missing PageRank mass lost
+    // through dangling nodes.
+    private[this] var totalMass: Float = Float.NegativeInfinity
+
+    override def reduce(nid: IntWritable, iterable: Iterable[PageRankNode], context: Context): Unit = {
+      val values = iterable.iterator
+
+      // Create the node structure that we're going to assemble back together from shuffled pieces.
+      val node = new PageRankNode
+
+      node.setType(PageRankNode.Type.Complete)
+      node.setNodeId(nid.get)
+
+      // Bookkeeping counters
+      var massMessagesReceived = 0
+      var structureReceived = 0
+      var mass = Float.NegativeInfinity
+
+      while(values.hasNext) {
+        val n = values.next
+
+        if(n.getType == PageRankNode.Type.Structure) {
+          // This is the structure; update accordingly.
+          val list = n.getAdjacencyList
+          structureReceived += 1
+
+          node.setAdjacencyList(list)
+        } else {
+          mass = sumLogProbs(mass, n.getPageRank)
+          massMessagesReceived += 1
+        }
+      }
+
+      // Update the final accumulated PageRank mass.
+      node.setPageRank(mass)
+      // Bookkeeping
+      context.getCounter(PageRankMessages.massMessagesReceived).increment(massMessagesReceived)
+
+      // Error checking
+      if(structureReceived == 1) {
+        // Everything checks out, emit final node structure with updated PageRank value.
+        context.write(nid, node)
+
+        // Keep track of total PageRank mass
+        totalMass = sumLogProbs(totalMass, mass)
+      } else if(structureReceived == 0) {
+        // We get into this situation if there exists an edge pointing to a node which has no
+        // corresponding node structure (i.e., PageRank mass was passed to a non-existent node)...
+        // log and count but move on.
+        context.getCounter(PageRankMessages.missingStructure).increment(1)
+        log.warn("No structure received for nodeid: " + nid.get + " mass: " + massMessagesReceived)
+        // It's important to note that we don't add the PageRank mass to total... if PageRank mass
+        // was sent to a non-existent node, it should simply vanish.
+      } else {
+        // This shouldn't happen!
+        throw new RuntimeException(s"Multiple structure received for nodeid: ${nid.get} " +
+          s"mass: $massMessagesReceived struct: $structureReceived")
+      }
+    }
+
+    override def cleanup(context: Context): Unit = {
+      val conf = context.getConfiguration
+      val taskId = conf.get("mapred.task.id")
+      val path = conf.get("PageRankMassPath")
+
+      Preconditions.checkNotNull(taskId)
+      Preconditions.checkNotNull(path)
+
+      // Write to a file the amount of PageRank mass we've seen in this reducer
+      val fs: FileSystem = FileSystem.get(context.getConfiguration)
+      val out: FSDataOutputStream = fs.create(new Path(s"$path/$taskId"), false)
+      out.writeFloat(totalMass)
+      out.close()
+    }
+  }
+
+  // Mapper that distributes the missing PageRank mass (lost at the dangling nodes) and takes care
+  // of the random jump factor.
+  private object MapPageRankMassDistributionClass extends TypedMapper[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+    private[this] var missingMass = 0.0f
+    private[this] var nodeCnt = 0
+
+    override def setup(context: Context): Unit = {
+      val conf = context.getConfiguration
+
+      missingMass = conf.getFloat("MissingMass", 0.0f)
+      nodeCnt = conf.getInt("NodeCount", 0)
+    }
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      val p = node.getPageRank
+
+      val jump = (Math.log(ALPHA) - Math.log(nodeCnt)).toFloat
+      val link: Float = Math.log(1.0f - ALPHA).toFloat +
+        sumLogProbs(p, (Math.log(missingMass) - Math.log(nodeCnt)).toFloat)
+
+      node.setPageRank(sumLogProbs(jump, link))
+      context.write(nid, node)
+    }
+
+  }
+
+  private val ALPHA: Float = 0.15f
+  private val formatter: NumberFormat = new DecimalFormat("0000")
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val base = opt[String](descr = "base path", required = true)
+    lazy val start = opt[Int](descr = "start iteration", required = true)
+    lazy val end = opt[Int](descr = "end iteration", required = true)
+    lazy val numNodes = opt[Int](descr = "number of nodes", required = true)
+
+    lazy val useCombiner = opt[Boolean](descr = "use combiner", required = false, default = Some(false))
+    lazy val useInMapperCombiner = opt[Boolean](descr = "use in-mapper combiner", required = false, default = Some(false))
+    lazy val range = opt[Boolean](descr = "use range partitioner", required = false, default = Some(false))
+
+    mainOptions = Seq(base, start, end, numNodes, useCombiner, useInMapperCombiner, range)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: RunPageRank")
+    log.info(" - base path: " + args.base())
+    log.info(" - num nodes: " + args.numNodes())
+    log.info(" - start iteration: " + args.start())
+    log.info(" - end iteration: " + args.end())
+    log.info(" - use combiner: " + args.useCombiner())
+    log.info(" - use in-mapper combiner: " + args.useInMapperCombiner())
+    log.info(" - use range partitioner: " + args.range())
+
+    // Iterate PageRank.
+    for(i <- args.start() until args.end()) {
+      iteratePageRank(i, i + 1, args.base(), args.numNodes(), args.useCombiner(), args.useInMapperCombiner())
+    }
+
+    0
+  }
+
+  private def iteratePageRank(i: Int, j: Int, basePath: String, numNodes: Int,
+                              useCombiner: Boolean, useInMapperCombiner: Boolean): Unit = {
+    // Each iteration consists of two phases (two MapReduce jobs).
+
+    // Job 1: distribute PageRank mass along outgoing edges
+    val mass = phase1(i, j, basePath, numNodes, useCombiner, useInMapperCombiner)
+
+    // Find out how much PageRank mass got lost at the dangling nodes
+    val missing = Math.max(0.0f, 1f - StrictMath.exp(mass).toFloat)
+
+    // Job 2: distribute missing mass, take care of random jump factor
+    phase2(i, j, missing, basePath, numNodes)
+  }
+
+  private def phase1(i: Int, j: Int, basePath: String, numNodes: Int,
+                     useCombiner: Boolean, useInMapperCombiner: Boolean): Float = {
+
+    val in = s"$basePath/iter" + formatter.format(i)
+    val out = s"$basePath/iter" + formatter.format(j) + "t"
+    val outm = s"$out-mass"
+
+
+    // We need to actually count the number of part files to get the number of partitions (because
+    // the directory might contain _log).
+    val numPartitions: Int = FileSystem.get(getConf)
+      .listStatus(new Path(in)).count(_.getPath.getName.contains("part-"))
+
+    log.info(s"PageRank: iteration $j: Phase1")
+    log.info(s" - input: $in")
+    log.info(s" - output: $out")
+    log.info(s" - nodeCnt: $numNodes")
+    log.info(s" - useCombiner: $useCombiner")
+    log.info(s" - useInMapCombiner: $useInMapperCombiner")
+    log.info(s"computed number of partitions: $numPartitions")
+
+    val jobConf = getConf
+    jobConf.setInt("NodeCount", numNodes)
+    jobConf.setBoolean("mapred.map.tasks.speculative.execution", false)
+    jobConf.setBoolean("mapred.reduce.tasks.speculative.execution", false)
+    jobConf.set("PageRankMassPath", outm)
+
+    val numReducers = numPartitions
+
+    val mapJob =
+      job(s"PageRank:Basic:iteration$j:Phase1", jobConf)
+        .file(new Path(in), classOf[NonSplitableSequenceFileInputFormat[IntWritable, PageRankNode]])
+        .map(if(useInMapperCombiner) MapWithInMapperCombiningClass else MapClass)
+
+    val reduceJob = { if(useCombiner) mapJob.combine(CombineClass) else mapJob }
+      .reduce(ReduceClass, numReducers)
+
+    FileSystem.get(jobConf).delete(new Path(outm), true)
+
+    time {
+      reduceJob.saveAsSequenceFile(new Path(out), deleteExisting = true)
+    }
+
+    val fs = FileSystem.get(getConf)
+    val mass = fs.listStatus(new Path(outm)).foldLeft(Float.NegativeInfinity)(
+      (m, f) => {
+        val fin = fs.open(f.getPath)
+        val nextMass = sumLogProbs(m, fin.readFloat)
+        fin.close()
+        nextMass
+      })
+
+    mass
+  }
+
+  private def phase2(i: Int, j: Int, missing: Float, basePath: String, numNodes: Int): Unit = {
+    val in = s"$basePath/iter" + formatter.format(j) + "t"
+    val out = s"$basePath/iter" + formatter.format(j)
+
+    log.info(s"PageRank: iteration $j: Phase2")
+    log.info(s" - input: $in")
+    log.info(s" - output: $out")
+
+    val jobConf = getConf
+    jobConf.setBoolean("mapred.map.tasks.speculative.execution", false)
+    jobConf.setBoolean("mapred.reduce.tasks.speculative.execution", false)
+    jobConf.setFloat("MissingMass", missing)
+    jobConf.setInt("NodeCount", numNodes)
+
+    val thisJob =
+      job(s"PageRank:Basic:iteration$j:Phase2", jobConf)
+        .file(new Path(in), classOf[NonSplitableSequenceFileInputFormat[IntWritable, PageRankNode]])
+        .map(MapPageRankMassDistributionClass)
+        .reduce(0)
+
+    time {
+      thisJob.saveAsSequenceFile(new Path(out), deleteExisting = true)
+    }
+  }
+
+  private def sumLogProbs(a: Float, b: Float): Float = {
+    if (a == Float.NegativeInfinity)
+      b
+    else if (b == Float.NegativeInfinity)
+      a
+    else if (a < b) {
+      (b + StrictMath.log1p(StrictMath.exp(a - b))).toFloat
+    } else {
+      (a + StrictMath.log1p(StrictMath.exp(b - a))).toFloat
+    }
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/pagerank/RunPageRankSchimmy.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/pagerank/RunPageRankSchimmy.scala
@@ -1,0 +1,497 @@
+package io.bespin.scala.mapreduce.pagerank
+
+import java.io.IOException
+import java.text.{DecimalFormat, NumberFormat}
+
+import com.google.common.base.Preconditions
+import io.bespin.java.mapreduce.pagerank.{NonSplitableSequenceFileInputFormat, PageRankMessages, PageRankNode}
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.io.{FloatWritable, IntWritable, SequenceFile, Writable}
+import org.apache.hadoop.mapreduce.lib.partition.HashPartitioner
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.map.HMapIF
+
+import scala.collection.JavaConverters._
+
+/**
+  * <p>
+  * Main driver program for running the Schimmy implementation of PageRank.
+  * </p>
+  *
+  * <p>
+  * The starting and ending iterations will correspond to paths
+  * <code>/base/path/iterXXXX</code> and <code>/base/path/iterYYYY</code>. As a
+  * example, if you specify 0 and 10 as the starting and ending iterations, the
+  * driver program will start with the graph structure stored at
+  * <code>/base/path/iter0000</code>; final results will be stored at
+  * <code>/base/path/iter0010</code>.
+  * </p>
+  *
+  * @see [[RunPageRankBasic]]
+  * @see [[io.bespin.java.mapreduce.pagerank.RunPageRankSchimmy]]
+  */
+object RunPageRankSchimmy extends BaseConfiguredTool with MapReduceSugar {
+
+  private object MapClass
+    extends TypedMapper[IntWritable, PageRankNode, IntWritable, FloatWritable] {
+    // The neighbor to which we're sending messages.
+    private val neighbor = new IntWritable
+
+    // Contents of the messages: partial PageRank mass.
+    private val intermediateMass = new FloatWritable
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      var massMessages = 0
+
+      // Distribute PageRank mass to neighbors (along outgoing edges)
+      val list = node.getAdjacencyList
+      if(list.size > 0) {
+        // Each neighbor gets an equal share of PageRank mass.
+        val mass = node.getPageRank - StrictMath.log(list.size).toFloat
+
+        // Iterate over neighbors.
+        for(i <- 0 until list.size) {
+          neighbor.set(list.get(i))
+          intermediateMass.set(mass)
+
+          // Emit messages with PageRank mass to neighbors.
+          context.write(neighbor, intermediateMass)
+          massMessages += 1
+        }
+      }
+
+      // Bookkeeping.
+      context.getCounter(PageRankMessages.nodes).increment(1)
+      context.getCounter(PageRankMessages.massMessages).increment(massMessages)
+    }
+  }
+
+  // Mapper with in-mapper combiner optimization.
+  private object MapWithInMapperCombiningClass
+    extends TypedMapper[IntWritable, PageRankNode, IntWritable, FloatWritable] {
+    // For buffering PageRank mass contributions keyed by destination node.
+    private val map = new HMapIF
+
+    // Clear the buffered values in case this mapper is re-used (as is the case when executing locally).
+    override def setup(context: Context): Unit = {
+      map.clear()
+    }
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      var massMessages = 0
+      var massMessagesSaved = 0
+
+      val list = node.getAdjacencyList
+
+      // Distribute PageRank mass to neighbors (along outgoing edges).
+      if(list.size > 0) {
+        // Each neighbor gets an equal share of PageRank mass.
+        val mass = node.getPageRank - StrictMath.log(list.size).toFloat
+
+        // Iterate over neighbors.
+        var i: Int = 0
+        while (i < list.size) {
+          val neighbor: Int = list.get(i)
+          if (map.containsKey(neighbor)) {
+            // Already message destined for that node; add PageRank mass contribution.
+            massMessagesSaved += 1
+            map.put(neighbor, sumLogProbs(map.get(neighbor), mass))
+          } else {
+            // New destination node; add new entry in map.
+            massMessages += 1
+            map.put(neighbor, mass)
+          }
+          i += 1
+        }
+      }
+
+      // Bookkeeping.
+      context.getCounter(PageRankMessages.nodes).increment(1)
+      context.getCounter(PageRankMessages.massMessages).increment(massMessages)
+      context.getCounter(PageRankMessages.massMessagesSaved).increment(massMessagesSaved)
+    }
+
+    override def cleanup(context: Context): Unit = {
+      // Now emit the messages all at once.
+      val k = new IntWritable
+      val v = new FloatWritable
+
+      for(e <- map.entrySet.asScala) {
+        k.set(e.getKey)
+        v.set(e.getValue)
+        context.write(k, v)
+      }
+    }
+  }
+
+  // Combiner: sums partial PageRank contributions.
+  private object CombineClass
+    extends TypedReducer[IntWritable, FloatWritable, IntWritable, FloatWritable] {
+    private val intermediateMass = new FloatWritable
+
+    override def reduce(nid: IntWritable, values: Iterable[FloatWritable], context: Context): Unit = {
+      // Remember, PageRank mass is stored as a log prob.
+      val (massMessages, mass) = values.foldLeft((0, Float.NegativeInfinity)){
+        case ((messages, massSum), next) =>
+          // Accumulate PageRank mass contributions
+          (messages + 1, sumLogProbs(massSum, next))
+      }
+
+      // emit aggregated results
+      if(massMessages > 0) {
+        intermediateMass.set(mass)
+        context.write(nid, intermediateMass)
+      }
+    }
+  }
+
+  // Reduce: sums incoming PageRank contributions, rewrite graph structure.
+  private object ReduceClass
+    extends TypedReducer[IntWritable, FloatWritable, IntWritable, PageRankNode] {
+    private var totalMass = Float.NegativeInfinity
+
+    private var reader: SequenceFile.Reader = _
+
+    private val hdfsNid = new IntWritable
+    private val hdfsNode = new PageRankNode
+
+    private var hdfsAhead = false
+
+    override def setup(context: Context): Unit = {
+      // We're going to open up the file on HDFS that has corresponding node structures.
+      // We get the task id and map it to the corresponding part.
+      val conf = context.getConfiguration
+
+      val taskId = conf.get("mapred.task.id")
+      Preconditions.checkNotNull(taskId)
+
+      // The partition mapping is passed in from the driver.
+      val mapping = conf.get("PartitionMapping")
+      Preconditions.checkNotNull(mapping)
+
+      val map: Map[Int, String] = mapping.split(";").map(s => {
+        val arr = s.split("=")
+
+        log.info(arr(0) + "\t" + arr(1))
+        arr(0).toInt -> arr(1)
+      }).toMap
+
+      // Get the part number
+      val partno = taskId.substring(taskId.length - 7, taskId.length - 2).toInt
+      val f = map(partno)
+
+      log.info(s"task id: $taskId")
+      log.info(s"partno: $partno")
+      log.info(s"file: $f")
+
+      // Try and open the node structures...
+      try {
+        reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(new Path(f)))
+      } catch {
+        case e: IOException =>
+          throw new RuntimeException(s"Couldn't open $f for partno: $partno within: $taskId")
+        case t: Throwable => throw t
+      }
+    }
+
+    override def reduce(nid: IntWritable, values: Iterable[FloatWritable], context: Context): Unit = {
+      // The basic algorithm is a merge sort between node structures on HDFS and intermediate
+      // key-value pairs coming into this reducer (where the keys are the node ids). Both are
+      // sorted, and the reducer is "pushed" intermediate key-value pairs, so the algorithm boils
+      // down to properly advancing the node structures file on HDFS.
+
+      // The HDFS node structure file is ahead. This means the incoming node ids don't have
+      // corresponding node structure (i.e., messages addressed to non-existent nodes). This may
+      // happen if the adjacency lists point to nodes that don't exist. Do nothing.
+      if(hdfsNid.get <= nid.get) {
+
+        // We need to advance the HDFS node structure file.
+        if(hdfsNid.get < nid.get) {
+          if(hdfsAhead) {
+            // If we get here, it means that no messages were sent to a particular node in the HDFS
+            // node structure file. So we want to emit this node structure.
+            hdfsNode.setPageRank(Float.NegativeInfinity)
+            context.write(hdfsNid, hdfsNode)
+            hdfsAhead = false
+          }
+
+          // We're now going to advance the HDFS node structure until we get to the node id of the
+          // current message we're processing...
+          while(reader.next(hdfsNid, hdfsNode) && hdfsNid.get != nid.get) {
+            // If we go past the incoming node id in the HDFS node structure file, then it means that
+            // no corresponding no structure exist. That is, a message was sent to a non-existent
+            // node: this may happen if adjacency lists point to nodes that don't exist.
+            if (hdfsNid.get > nid.get) {
+              hdfsAhead = true
+              return
+            }
+
+            // This is a node that has not messages sent to it... we don't want to node the node
+            // structure, so just emit.
+            hdfsNode.setPageRank(Float.NegativeInfinity)
+            context.write(hdfsNid, hdfsNode)
+          }
+        }
+
+        // If we get here, it means that the reader ran out of nodes, i.e., next method returned
+        // false. This means that the messages were addressed to non-existent nodes.
+        if (hdfsNid.get != nid.get) return
+      }
+
+      val (massMessagesReceived, mass) = values.foldLeft((0, Float.NegativeInfinity)) {
+        case ((messages, massSum), next) => (messages + 1, sumLogProbs(massSum, next))
+      }
+
+      totalMass = sumLogProbs(totalMass, mass)
+
+      // Populate the node structure with the updated PageRank value.
+      hdfsNode.setPageRank(mass)
+
+      // Emit!
+      context.write(nid, hdfsNode)
+      context.getCounter(PageRankMessages.massMessagesReceived).increment(massMessagesReceived)
+
+      hdfsAhead = false
+    }
+
+    override def cleanup(context: Context): Unit = {
+      val conf = context.getConfiguration
+      val taskId = conf.get("mapred.task.id")
+      val path = conf.get("PageRankMassPath")
+
+      Preconditions.checkNotNull(taskId)
+      Preconditions.checkNotNull(path)
+
+      val fs = FileSystem.get(conf)
+      val out = fs.create(new Path(s"$path/$taskId"), false)
+      out.writeFloat(totalMass)
+      out.close()
+
+      // If the HDFS node structure file is ahead, we want to emit the current node structure.
+      if(hdfsAhead) {
+        hdfsNode.setPageRank(Float.NegativeInfinity)
+        context.write(hdfsNid, hdfsNode)
+        hdfsAhead = false
+      }
+
+      // We have to write out the rest of the nodes we haven't finished reading yet (i.e., these are
+      // the ones who don't have any messages sent to them)
+      while (reader.next(hdfsNid, hdfsNode)) {
+        hdfsNode.setPageRank(Float.NegativeInfinity)
+        context.write(hdfsNid, hdfsNode)
+      }
+
+      reader.close()
+    }
+  }
+
+  // Mapper that distributes the missing PageRank mass (lost at the dangling nodes) and takes care
+  // of the random jump factor.
+  private object MapPageRankMassDistributionClass
+    extends TypedMapper[IntWritable, PageRankNode, IntWritable, PageRankNode] {
+    private var missingMass = 0.0f
+    private var nodeCnt = 0
+
+    override def setup(context: Context): Unit = {
+      val conf = context.getConfiguration
+
+      missingMass = conf.getFloat("MissingMass", 0.0f)
+      nodeCnt = conf.getInt("NodeCount", 0)
+    }
+
+    override def map(nid: IntWritable, node: PageRankNode, context: Context): Unit = {
+      val p = node.getPageRank
+
+      val jump = (Math.log(ALPHA) - Math.log(nodeCnt)).toFloat
+      val link = Math.log(1.0 - ALPHA).toFloat +
+        sumLogProbs(p, (Math.log(missingMass) - Math.log(nodeCnt)).toFloat)
+
+      node.setPageRank(sumLogProbs(jump, link))
+      context.write(nid, node)
+    }
+  }
+
+  private val ALPHA: Float = 0.15f
+  private val FORMAT: NumberFormat = new DecimalFormat("0000")
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val base = opt[String](descr = "base path", required = true)
+    lazy val start = opt[Int](descr = "start iteration", required = true)
+    lazy val end = opt[Int](descr = "end iteration", required = true)
+    lazy val numNodes = opt[Int](descr = "number of nodes", required = true)
+
+    lazy val useCombiner = opt[Boolean](descr = "use combiner", required = false, default = Some(false))
+    lazy val useInMapperCombiner = opt[Boolean](descr = "use in-mapper combiner", required = false, default = Some(false))
+    lazy val range = opt[Boolean](descr = "use range partitioner", required = false, default = Some(false))
+
+    mainOptions = Seq(base, start, end, numNodes, useCombiner, useInMapperCombiner, range)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Tool name: RunPageRank")
+    log.info(" - base path: " + args.base())
+    log.info(" - num nodes: " + args.numNodes())
+    log.info(" - start iteration: " + args.start())
+    log.info(" - end iteration: " + args.end())
+    log.info(" - use combiner: " + args.useCombiner())
+    log.info(" - use in-mapper combiner: " + args.useInMapperCombiner())
+    log.info(" - use range partitioner: " + args.range())
+
+    // Iterate PageRank.
+    for(i <- args.start() until args.end()) {
+      iteratePageRank(args.base(), i, i + 1, args.numNodes(), args.useCombiner(), args.useInMapperCombiner(), args.range())
+    }
+
+    0
+  }
+
+  private object ThisRangePartitioner extends RangePartitioner[FloatWritable]
+
+  // Run each iteration.
+  private def iteratePageRank(path: String, i: Int, j: Int, n: Int, useCombiner: Boolean,
+                              useInMapCombiner: Boolean, useRange: Boolean): Unit = {
+    // Each iteration consists of two phases (two MapReduce jobs).
+    // Job1: distribute PageRank mass along outgoing edges.
+    val mass = phase1(path, i, j, n, useCombiner, useInMapCombiner, useRange)
+
+    // Find out how much PageRank mass got lost at the dangling nodes.
+    val missing: Float = Math.max(0.0f, 1.0f - StrictMath.exp(mass).toFloat)
+
+    // Job2: distribute missing mass, take care of random jump factor.
+    phase2(path, i, j, n, missing)
+
+  }
+
+  private def phase1(path: String, i: Int, j: Int, n: Int, useCombiner: Boolean,
+                     useInMapCombiner: Boolean, useRange: Boolean): Float = {
+    val conf = getConf
+
+    val in = path + "/iter" + FORMAT.format(i)
+    val out = path + "/iter" + FORMAT.format(j) + "t"
+    val outm = out + "-mass"
+
+    // We need to actually count the number of part files to get the number
+    // of partitions (because the directory might contain _log).
+    val numPartitions = FileSystem.get(conf).listStatus(new Path(in))
+      .count(_.getPath.getName.contains("part-"))
+
+    conf.setInt("NodeCount", n)
+
+    val partitioner = if(useRange) {
+      val p = new RangePartitioner[PageRankNode]
+      p.setConf(conf)
+      p
+    } else {
+      new HashPartitioner[IntWritable, Writable]
+    }
+
+    // This is really annoying: the mapping between the partition numbers on
+    // disk (i.e., part-XXXX) and what partition the file contains (i.e.,
+    // key.hash % #reducer) is arbitrary... so this means that we need to
+    // open up each partition, peek inside to find out.
+    val key: IntWritable = new IntWritable
+    val value: PageRankNode = new PageRankNode
+    val status: Array[FileStatus] = FileSystem.get(conf).listStatus(new Path(in))
+
+    val sb: StringBuilder = new StringBuilder
+    val paths: String = status.withFilter(_.getPath.getName.contains("part-")).map(f => {
+      val reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(f.getPath))
+
+      reader.next(key, value)
+      val np = partitioner.getPartition(key, value, numPartitions)
+      reader.close()
+
+      log.info(f.getPath + "\t" + np)
+      np + "=" + f.getPath + ";"
+    }).foldLeft("")(_ ++ _)
+
+    log.info(paths.trim)
+
+    log.info("PageRankSchimmy: iteration " + j + ": Phase1")
+    log.info(" - input: " + in)
+    log.info(" - output: " + out)
+    log.info(" - nodeCnt: " + n)
+    log.info(" - useCombiner: " + useCombiner)
+    log.info(" - useInmapCombiner: " + useInMapCombiner)
+    log.info(" - numPartitions: " + numPartitions)
+    log.info(" - useRange: " + useRange)
+    log.info("computed number of partitions: " + numPartitions)
+
+    val numReduceTasks = numPartitions
+
+    conf.setInt("mapred.min.split.size", 1024 * 1024 * 1024)
+    //conf.set("mapred.child.java.opts", "-Xmx2048m");
+
+    conf.set("PageRankMassPath", outm)
+    conf.set("BasePath", in)
+    conf.set("PartitionMapping", paths.trim)
+
+    conf.setBoolean("mapred.map.tasks.speculative.execution", false)
+    conf.setBoolean("mapred.reduce.tasks.speculative.execution", false)
+
+    val thisJob = job(s"PageRankSchimmy:iteration$j:Phase1", conf)
+      .sequenceFile[IntWritable, PageRankNode](in)
+
+    val mappedJob = thisJob.map(if(useInMapCombiner) MapWithInMapperCombiningClass else MapClass)
+    val partitionedJob = if(useRange) mappedJob.partition(ThisRangePartitioner) else mappedJob
+    val reducedJob = {if(useCombiner) partitionedJob.combine(CombineClass) else partitionedJob}
+      .reduce(ReduceClass, numReduceTasks)
+
+    FileSystem.get(conf).delete(outm, true)
+
+    time {
+      reducedJob.saveAsSequenceFile(out, deleteExisting = true)
+    }
+
+    val fs = FileSystem.get(getConf)
+    val mass = fs.listStatus(new Path(outm)).foldLeft(Float.NegativeInfinity)(
+      (m, f) => {
+        val fin = fs.open(f.getPath)
+        val nextMass = sumLogProbs(m, fin.readFloat)
+        fin.close()
+        nextMass
+      })
+
+    mass
+  }
+
+  private def phase2(path: String, i: Int, j: Int, n: Int, missing: Float): Unit = {
+    val in = s"$path/iter" + FORMAT.format(j) + "t"
+    val out = s"$path/iter" + FORMAT.format(j)
+
+    log.info(s"PageRank: iteration $j: Phase2")
+    log.info(s" - input: $in")
+    log.info(s" - output: $out")
+
+    val jobConf = getConf
+    jobConf.setBoolean("mapred.map.tasks.speculative.execution", false)
+    jobConf.setBoolean("mapred.reduce.tasks.speculative.execution", false)
+    jobConf.setFloat("MissingMass", missing)
+    jobConf.setInt("NodeCount", n)
+
+    val thisJob =
+      job(s"PageRank:Basic:iteration$j:Phase2", jobConf)
+        .file(new Path(in), classOf[NonSplitableSequenceFileInputFormat[IntWritable, PageRankNode]])
+        .map(MapPageRankMassDistributionClass)
+        .reduce(0)
+
+    time {
+      thisJob.saveAsSequenceFile(new Path(out), deleteExisting = true)
+    }
+  }
+
+  private def sumLogProbs(a: Float, b: Float): Float = {
+    if (a == Float.NegativeInfinity)
+      b
+    else if (b == Float.NegativeInfinity)
+      a
+    else if (a < b) {
+      (b + StrictMath.log1p(StrictMath.exp(a - b))).toFloat
+    } else {
+      (a + StrictMath.log1p(StrictMath.exp(b - a))).toFloat
+    }
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/search/BooleanRetrieval.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/search/BooleanRetrieval.scala
@@ -1,0 +1,112 @@
+package io.bespin.scala.mapreduce.search
+
+import java.io.{InputStreamReader, BufferedReader}
+
+import io.bespin.scala.mapreduce.util.{MapReduceSugar, BaseConfiguredTool}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path, FSDataInputStream, FileSystem}
+import org.apache.hadoop.io.{Text, IntWritable, MapFile}
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListWritable
+import tl.lin.data.pair.{PairOfWritables, PairOfInts}
+
+import scala.collection.immutable.SortedSet
+import scala.collection.mutable
+
+import scala.collection.JavaConverters._
+
+object BooleanRetrieval extends BaseConfiguredTool with MapReduceSugar {
+
+  private def runQuery(q: String, index: MapFile.Reader, collection: FSDataInputStream): Unit = {
+    val terms = q.split("""\s+""")
+
+    val stack = new mutable.Stack[SortedSet[Int]]()
+    terms.foreach {
+      case "AND" => performAND(stack)
+      case "OR" => performOR(stack)
+      case t => pushTerm(t, stack, index)
+    }
+
+    val result = stack.pop()
+    result.foreach { i =>
+      val line = fetchLine(i, collection)
+      println(s"$i\t$line")
+    }
+  }
+
+  private def pushTerm(term: String, stack: mutable.Stack[SortedSet[Int]], index: MapFile.Reader): Unit = {
+    stack.push(fetchDocumentSet(term, index))
+  }
+
+  private def performOR(stack: mutable.Stack[SortedSet[Int]]): Unit = {
+    val s1 = stack.pop()
+    val s2 = stack.pop()
+
+    stack.push(s1.union(s2))
+  }
+
+  private def performAND(stack: mutable.Stack[SortedSet[Int]]): Unit = {
+    val s1 = stack.pop()
+    val s2 = stack.pop()
+
+    stack.push(s1.intersect(s2))
+  }
+
+  private def fetchDocumentSet(term: String, index: MapFile.Reader): SortedSet[Int] = {
+    val set = SortedSet.newBuilder[Int]
+    fetchPostings(term, index).asScala.foreach(p => set += p.getLeftElement)
+    set.result()
+  }
+
+  private def fetchPostings(term: String, index: MapFile.Reader): ArrayListWritable[PairOfInts] = {
+    val key: Text = term
+    val value: PairOfWritables[IntWritable, ArrayListWritable[PairOfInts]] = new PairOfWritables()
+    index.get(key, value)
+    value.getRightElement
+  }
+
+  private def fetchLine(offset: Long, collection: FSDataInputStream): String = {
+    collection.seek(offset)
+    val reader = new BufferedReader(new InputStreamReader(collection))
+
+    val d = reader.readLine()
+    if(d.length > 80)
+      d.substring(0, 80) + "..."
+    else
+      d
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val index = opt[String](descr = "index path",  required = true)
+    lazy val collection = opt[String](descr = "collection path", required = true)
+    lazy val query = opt[String](descr = "query", required = true)
+
+    mainOptions = Seq(index, collection, query)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    if(args.collection().endsWith(".gz")) {
+      log.error("gzipped collection is not seekable: use compresed version!")
+      -1
+    } else {
+
+      val fs = FileSystem.get(new Configuration())
+      val index = new MapFile.Reader(new Path(args.index() + "/part-r-00000"), fs.getConf)
+      val collection = fs.open(new Path(args.collection()))
+
+      println("Query: " + args.query())
+      val startTime = System.currentTimeMillis()
+
+      runQuery(args.query(), index, collection)
+
+      println("\nquery completed in " + (System.currentTimeMillis() - startTime) + " ms")
+
+      index.close()
+      collection.close()
+
+      1
+    }
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/search/BuildInvertedIndex.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/search/BuildInvertedIndex.scala
@@ -1,0 +1,83 @@
+package io.bespin.scala.mapreduce.search
+
+import java.util.Collections
+
+import io.bespin.scala.mapreduce.util.{TypedReducer, TypedMapper, MapReduceSugar, BaseConfiguredTool}
+import io.bespin.scala.util.Tokenizer
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.{IntWritable, Text, LongWritable}
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListWritable
+import tl.lin.data.fd.{Object2IntFrequencyDistributionEntry, Object2IntFrequencyDistribution}
+import tl.lin.data.pair.{PairOfWritables, PairOfInts}
+
+import scala.collection.JavaConverters._
+
+object BuildInvertedIndex extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
+
+  private type IndexRow = PairOfWritables[IntWritable, ArrayListWritable[PairOfInts]]
+
+  private object MyMapper extends TypedMapper[LongWritable, Text, Text, PairOfInts] {
+    private val counts: Object2IntFrequencyDistribution[String] =
+      new Object2IntFrequencyDistributionEntry[String]()
+
+    override def map(docno: LongWritable, value: Text, context: Context): Unit = {
+      val tokens = tokenize(value)
+
+      // Build a histogram of the terms
+      counts.clear()
+      tokens.foreach( counts.increment )
+
+      val id = docno.get().toInt
+
+      // Emit postings
+      counts.iterator().asScala.foreach { e =>
+        context.write(e.getLeftElement, (id, e.getRightElement))
+      }
+    }
+  }
+
+  private object MyReducer extends TypedReducer[Text, PairOfInts, Text, IndexRow] {
+    override def reduce(key: Text, values: Iterable[PairOfInts], context: Context): Unit = {
+      val iter = values.iterator
+
+      val postings = new ArrayListWritable[PairOfInts]()
+      while(iter.hasNext) {
+        postings.add(iter.next().clone())
+      }
+
+      Collections.sort(postings)
+
+      val docFreq: IntWritable = postings.size
+      context.write(key, (docFreq, postings))
+    }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+
+    mainOptions = Seq(input, output)
+  }
+
+  override def run(argv: Array[String]): Int = {
+    val args = new Conf(argv)
+
+    log.info("Input: " + args.input())
+    log.info("Output: " + args.output())
+
+    val thisJob =
+      job("Inverted Index Construction", getConf)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(MyMapper)
+        .reduce(MyReducer)
+
+    time {
+      thisJob.saveAsMapFile(args.output())
+    }
+
+    0
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/search/LookupPostings.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/search/LookupPostings.scala
@@ -1,0 +1,79 @@
+package io.bespin.scala.mapreduce.search
+
+import java.io.{InputStreamReader, BufferedReader}
+
+import io.bespin.scala.util.WritableConversions
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.apache.hadoop.io.{IntWritable, MapFile}
+import org.rogach.scallop.ScallopConf
+import tl.lin.data.array.ArrayListWritable
+import tl.lin.data.fd.Int2IntFrequencyDistributionEntry
+import tl.lin.data.pair.{PairOfWritables, PairOfInts}
+
+import scala.collection.JavaConverters._
+
+object LookupPostings extends WritableConversions {
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val index = opt[String](descr = "index path",  required = true)
+    lazy val collection = opt[String](descr = "collection path", required = true)
+    lazy val term = opt[String](descr = "term", required = true)
+
+    mainOptions = Seq(index, collection, term)
+  }
+
+  private def lookupTerm(term: String, reader: MapFile.Reader, collectionPath: String, fs: FileSystem): Unit = {
+    val collection = fs.open(new Path(collectionPath))
+
+    val value = new PairOfWritables[IntWritable, ArrayListWritable[PairOfInts]]()
+    val w = Option(reader.get(term, value))
+
+    w match {
+      case Some(t) =>
+        val postings = value.getRightElement
+        println(s"\nComplete postings list for '$term':")
+        println("df = " + value.getLeftElement)
+
+        val hist = new Int2IntFrequencyDistributionEntry()
+        postings.iterator().asScala.foreach { pair =>
+          hist.increment(pair.getRightElement)
+          print(pair)
+          collection.seek(pair.getLeftElement)
+          val r = new BufferedReader(new InputStreamReader(collection))
+
+          val d = r.readLine()
+          if(d.length > 80)
+            println(s": ${d.substring(0, 80)}...")
+          else
+            println(s": $d")
+        }
+
+        println(s"\nHistogram of tf values for '$term'")
+        hist.iterator().asScala.foreach(pair => println(pair.getLeftElement + "\t" + pair.getRightElement))
+        collection.close()
+
+      case None =>
+        println(s"\nThe term '$term' does not appear in the collection")
+    }
+
+  }
+
+  def main(argv: Array[String]): Unit = {
+    val args = new Conf(argv)
+
+    if(args.collection().endsWith(".gz")) {
+      println("gzipped collection is not seekable: use compressed version!")
+      System.exit(-1)
+    }
+
+    val config = new Configuration()
+    val fs = FileSystem.get(config)
+    val reader = new MapFile.Reader(new Path(args.index() + "/part-r-00000"), config)
+
+    lookupTerm(args.term(), reader, args.collection(), fs)
+
+    reader.close()
+  }
+
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/util/BaseConfiguredTool.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/util/BaseConfiguredTool.scala
@@ -1,0 +1,30 @@
+package io.bespin.scala.mapreduce.util
+
+import org.apache.hadoop.conf.{Configuration, Configured}
+import org.apache.hadoop.util.{ToolRunner, Tool}
+import org.apache.log4j._
+
+/**
+  * Base trait for creating entry points for MapReduce jobs
+  */
+trait BaseConfiguredTool extends Configured with Tool { self =>
+  /** Initialize configuration */
+  setConf(new Configuration())
+
+  protected lazy val log = Logger.getLogger(self.getClass)
+
+  /**
+    * Function which logs the running time of any function in seconds.
+    * Note that this only measures the rough amount of time it takes for "f" to return, and is not suitable for benchmarks
+    * which require precise measurements.
+    */
+  def time(f: => Unit): Unit = {
+    val startTime: Long = System.currentTimeMillis()
+    f
+    log.info("Job Finished in " + (System.currentTimeMillis() - startTime) / 1000.0 + " seconds")
+  }
+
+  def main(args: Array[String]) {
+    ToolRunner.run(self, args)
+  }
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/util/BaseUtil.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/util/BaseUtil.scala
@@ -1,0 +1,43 @@
+package io.bespin.scala.mapreduce.util
+
+import scala.reflect.runtime.universe.{TypeTag => TT}
+
+/**
+  * A decorator trait providing an implicit mirror belonging to the implementing class' classloader.
+  */
+trait WithMirror { self =>
+  protected[util] implicit val typeMirror: reflect.runtime.universe.Mirror =
+    reflect.runtime.universe.runtimeMirror(self.getClass.getClassLoader)
+}
+
+/**
+  * A decorator trait providing an implicit Class[_] object of the implementing class. Useful for
+  * calling Job.setJarByClass (which Hadoop uses to look up the jar of the class creating/running the job)
+  */
+trait WithCallingClass { self =>
+  implicit protected[util] val thisClass: Class[_] = self.getClass
+}
+
+/**
+  * An interface which provides the runtime types of its key and value classes
+  */
+trait WithTypedOutput[KO, VO] {
+
+  protected[util] val kEv: TT[KO]
+
+  protected[util] val vEv: TT[VO]
+
+  protected[util] def outputKeyType(implicit mirror: reflect.runtime.universe.Mirror): mirror.universe.RuntimeClass =
+    mirror.runtimeClass(kEv.tpe.typeSymbol.asClass)
+
+  protected[util] def outputValueType(implicit mirror: reflect.runtime.universe.Mirror): mirror.universe.RuntimeClass =
+    mirror.runtimeClass(vEv.tpe.typeSymbol.asClass)
+
+}
+
+/**
+  * A decorator trait providing a typed class symbol
+  */
+trait WrappedWithClazz[T] {
+  protected[util] val clazz: Class[T]
+}

--- a/src/main/scala/io/bespin/scala/mapreduce/util/MapReduceSugar.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/util/MapReduceSugar.scala
@@ -1,0 +1,511 @@
+package io.bespin.scala.mapreduce.util
+
+import io.bespin.scala.util.{PairWritableConversions, WritableConversions}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.io.{LongWritable, Text, WritableComparable}
+import org.apache.hadoop.mapreduce._
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, SequenceFileInputFormat, TextInputFormat}
+import org.apache.hadoop.mapreduce.lib.output.{FileOutputFormat, MapFileOutputFormat, SequenceFileOutputFormat, TextOutputFormat}
+
+import scala.collection.JavaConverters._
+import scala.language.{higherKinds, implicitConversions}
+import scala.reflect.runtime.universe.{typeOf, typeTag, TypeTag => TT}
+
+/**
+  * TypedMapper provides a scala wrapper to the Mapper class which reduces boilerplate and captures the run-time
+  * output key and value types.
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  * @tparam KO Key Output type
+  * @tparam VO Value Output type
+  */
+abstract class TypedMapper[KI,VI,KO:TT,VO:TT] extends Mapper[KI,VI,KO,VO] with WithTypedOutput[KO,VO] {
+
+  protected[util] final val kEv = typeTag[KO]
+  protected[util] final val vEv = typeTag[VO]
+
+  protected final type Context = Mapper[KI,VI,KO,VO]#Context
+
+  override def map(key: KI, value: VI, context: Context): Unit = super.map(key, value, context)
+
+  override def setup(context: Context): Unit = super.setup(context)
+
+  override def cleanup(context: Context): Unit = super.cleanup(context)
+}
+
+/**
+  * TypedReducer provides a scala wrapper to the Reducer class which reduces boilerplate and captures the run-time
+  * output key and value types.
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  * @tparam KO Key Output type
+  * @tparam VO Value Output type
+  */
+abstract class TypedReducer[KI,VI,KO:TT,VO:TT] extends Reducer[KI,VI,KO,VO] with WithTypedOutput[KO,VO] {
+
+  protected[util] final val kEv = typeTag[KO]
+  protected[util] final val vEv = typeTag[VO]
+
+  protected final type Context = Reducer[KI,VI,KO,VO]#Context
+
+  /** Final overridden reduce method which handles conversion of 'values' to a scala Iterable */
+  override final def reduce(key: KI, values: java.lang.Iterable[VI], context: Context): Unit = reduce(key, values.asScala, context)
+
+  def reduce(key: KI, values: Iterable[VI], context: Context): Unit = super.reduce(key, values.asJava, context)
+
+  override def setup(context: Context): Unit = super.setup(context)
+
+  override def cleanup(context: Context): Unit = super.cleanup(context)
+
+}
+
+/**
+  * A wrapped instance of a MapReduce Mapper object which encapsulates the type arguments of the Mapper
+  * with TypeTags and provides a relatively type-safe way to get the class of the Mapper
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  * @tparam KO Key Output type
+  * @tparam VO Value Output type
+  */
+case class WrappedMapper[KI,VI,KO,VO](m: Mapper[KI,VI,KO,VO])(implicit val kEv: TT[KO], val vEv: TT[VO])
+  extends WithTypedOutput[KO,VO]
+    with WrappedWithClazz[Mapper[KI,VI,KO,VO]] { self =>
+  protected[util] val clazz: Class[Mapper[KI, VI, KO, VO]] = m.getClass.asInstanceOf[Class[Mapper[KI,VI,KO,VO]]]
+}
+
+/**
+  * A wrapped instance of a MapReduce Reducer object which encapsulates the type arguments of the Reducer
+  * with TypeTags and provides a relatively type-safe way to get the class of the Reducer
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  * @tparam KO Key Output type
+  * @tparam VO Value Output type
+  */
+case class WrappedReducer[KI,VI,KO,VO](r: Reducer[KI,VI,KO,VO])(implicit val kEv: TT[KO], val vEv: TT[VO]) extends WithTypedOutput[KO,VO]
+  with WrappedWithClazz[Reducer[KI,VI,KO,VO]] {
+  protected[util] val clazz: Class[Reducer[KI, VI, KO, VO]] = r.getClass.asInstanceOf[Class[Reducer[KI,VI,KO,VO]]]
+}
+
+/**
+  * A wrapped instance of a MapReduce Partitioner object which encapsulates the type arguments of the Partitioner
+  * with TypeTags and provides a relatively type-safe way to get the class of the Partitioner
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  */
+case class WrappedPartitioner[KI,VI](p: Partitioner[KI,VI])(implicit val kEv: TT[KI], val vEv: TT[VI]) extends WithTypedOutput[KI,VI]
+  with WrappedWithClazz[Partitioner[KI,VI]] {
+  protected[util] val clazz: Class[Partitioner[KI, VI]] = p.getClass.asInstanceOf[Class[Partitioner[KI,VI]]]
+}
+
+/**
+  * An implementation of HasJob returns a Job object with possible configuration applied
+  * to it. It may create this Job object itself, or have it passed in from another source.
+  */
+sealed trait HasJob {
+  def job(implicit mirror: reflect.runtime.universe.Mirror): Job
+}
+
+/**
+  * A Stage is some hadoop job component which produces a typed output
+  */
+sealed trait Stage[K,V] extends HasJob with WithTypedOutput[K, V]
+
+/**
+  * StageFromtype is a wrapper abstract class which fills in the key and value type information using some other
+  * object which provides key and value information.
+  */
+abstract sealed class StageFromType[K,V](typeSource: WithTypedOutput[K,V]) extends Stage[K,V] {
+  override protected[util] final val kEv: TT[K] = typeSource.kEv
+  override protected[util] final val vEv: TT[V] = typeSource.vEv
+}
+
+/**
+  * BaseJob is the root class for creating a MapReduce job using the syntactic sugar provided in this
+  * and related classes.
+  *
+  * @param name Name of the Hadoop job.
+  * @param initialConfig Optional initial Configuration (can be None)
+  * @param callingClass Class symbol of the calling class (needed by Hadoop to determine the source jar)
+  */
+case class BaseJob(name: String, initialConfig: Option[Configuration] = None, callingClass: Class[_]) extends HasJob {
+  def job(implicit mirror: reflect.runtime.universe.Mirror): Job = {
+    val j = initialConfig.fold(Job.getInstance)(Job.getInstance)
+    j.setJobName(name)
+    j.setJarByClass(callingClass)
+    j
+  }
+}
+
+/**
+  * An InputDefinition describes the input format of a particular Job
+  *
+  * @tparam KI Key Input type
+  * @tparam VI Value Input type
+  */
+sealed trait InputDefinition[KI,VI] extends Stage[KI,VI]
+
+/**
+  * An OutputDefinition describes the output format of a particular Job.
+  * Once an OutputDefinition (and all its prerequisites) have been fully defined, the Job can be
+  * run as a MapReduce job.
+  *
+  * @tparam KO Key Output type
+  * @tparam VO Value Output type
+  */
+sealed trait OutputDefinition[KO,VO] extends Stage[KO,VO] {
+
+  /**
+    * Runs the constructed MapReduce Job
+    *
+    * @param verbose Enables verbose logging output
+    * @param mirror Implicit type mirror used for resolving runtime types of arguments
+    */
+  def run(verbose: Boolean = true)(implicit mirror: reflect.runtime.universe.Mirror): Boolean = {
+    job.waitForCompletion(verbose)
+  }
+}
+
+case class FileInputDefinition[KI:TT, VI:TT](baseJob: BaseJob,
+                                             path: Path,
+                                             inputFormat: Class[_<:FileInputFormat[KI,VI]]) extends InputDefinition[KI,VI] {
+  def job(implicit mirror: reflect.runtime.universe.Mirror) = {
+    val jobIn = baseJob.job
+    FileInputFormat.addInputPath(jobIn, path)
+    jobIn.setInputFormatClass(inputFormat)
+    jobIn
+  }
+
+  override protected[util] val kEv: TT[KI] = typeTag[KI]
+  override protected[util] val vEv: TT[VI] = typeTag[VI]
+}
+
+case class FileOutputDefinition[KO, VO](stage: Stage[KO,VO],
+                                        path: Path,
+                                        outputFormat: Class[_ <: FileOutputFormat[_,_]] = classOf[TextOutputFormat[KO,VO]],
+                                        deleteExisting: Boolean = true) extends StageFromType[KO,VO](stage) with OutputDefinition[KO,VO] {
+  def job(implicit mirror: reflect.runtime.universe.Mirror) = {
+    val jobIn = stage.job
+    FileOutputFormat.setOutputPath(jobIn, path)
+    jobIn.setOutputFormatClass(outputFormat)
+    if (deleteExisting)
+      FileSystem.get(jobIn.getConfiguration).delete(path, true)
+
+    jobIn
+  }
+
+  def withFormat[F1 <: FileOutputFormat[KO, VO] : TT](implicit mirror: reflect.runtime.universe.Mirror) =
+    this.copy[KO, VO](outputFormat = mirror.runtimeClass(typeOf[F1].typeSymbol.asClass).asInstanceOf[Class[F1]])
+}
+
+/**
+  * A MapStage object encapsulates the logic for setting the relevant Hadoop job parameters for the given mapper.
+  * @param input Input stage; must not already have a mapper class set.
+  * @param mapper Mapper object to set the Hadoop job to use
+  */
+case class MapStage[KI,VI,KO,VO](input: Stage[KI,VI],
+                                 mapper: Option[WrappedMapper[KI,VI,KO,VO]] = None)
+  extends StageFromType[KO,VO](mapper.getOrElse(input).asInstanceOf[WithTypedOutput[KO,VO]]) {
+
+  override def job(implicit mirror: reflect.runtime.universe.Mirror): Job = {
+    val jobIn = input.job
+
+    val stageType = mapper.getOrElse(input)
+
+    jobIn.setMapOutputKeyClass(stageType.outputKeyType)
+    jobIn.setMapOutputValueClass(stageType.outputValueType)
+    val currentMapper = Option(jobIn.getMapperClass)
+    // Throw an exception if a non-default mapper is found to be on the job already
+    if(currentMapper != Some(classOf[Mapper[_,_,_,_]])) {
+      throw new IllegalArgumentException(
+        "Attempted to set a mapper on a Hadoop job, but found one set on the job already. " +
+          "Are you calling map() twice?"
+      )
+    }
+    mapper.foreach(m => jobIn.setMapperClass(m.clazz))
+    jobIn
+  }
+}
+
+/**
+  * A CombineStage object encapsulates the logic for setting the relevant Hadoop job parameters for the given combiner.
+  * @param input Input stage; must not already have a combiner class set.
+  * @param combiner Combiner object to set the Hadoop job to use.
+  */
+case class CombineStage[K,V](input: Stage[K,V],
+                             combiner: Option[WrappedReducer[K,V,K,V]] = None)
+  extends StageFromType[K,V](input) {
+
+  override def job(implicit mirror: reflect.runtime.universe.Mirror): Job = {
+    val jobIn = input.job
+    val currentCombiner = Option(jobIn.getCombinerClass)
+    // Throw an exception if a non-default combiner is found to be on the job already
+    if(currentCombiner.isDefined) {
+      throw new IllegalArgumentException(
+        "Attempted to set a combiner on a Hadoop job, but found one set on the job already. " +
+          "Are you calling combine() twice?"
+      )
+    }
+    combiner.foreach(c => jobIn.setCombinerClass(c.clazz))
+    jobIn
+  }
+}
+
+/**
+  * A PartitionStage object encapsulates the logic for setting the relevant Hadoop job parameters for the given
+  * partitioner.
+  *
+  * @param input Input stage
+  * @param partitioner Partitioner object to set the Hadoop job to use; will overwrite any existing partitioner already
+  *                    set for the job.
+  */
+case class PartitionStage[K,V](input: Stage[K,V],
+                               partitioner: Option[WrappedPartitioner[K,V]] = None)
+  extends StageFromType[K,V](input) {
+
+  override def job(implicit mirror: reflect.runtime.universe.Mirror): Job = {
+    val jobIn = input.job
+    // Unfortunately cannot reliably check to see if partitioner is set here because the default partitioner
+    // can be a number of different classes.
+    partitioner.foreach(p => jobIn.setPartitionerClass(p.clazz))
+    jobIn
+  }
+}
+
+/**
+  * A ReduceStage object encapsulates the logic for setting the relevant Hadoop job parameters for the given
+  * reduce stage and number of reducers
+  *
+  * @param input Input stage; must not have already had a reducer set
+  * @param reducer Reducer object to set the Hadoop job to use
+  * @param numReducers Number of reduce tasks to run
+  */
+case class ReduceStage[KI,VI,KO,VO](input: Stage[KI,VI],
+                                    reducer: Option[WrappedReducer[KI,VI,KO,VO]] = None,
+                                    numReducers: Int = 1)
+  extends StageFromType[KO,VO](reducer.getOrElse(input).asInstanceOf[WithTypedOutput[KO,VO]]) {
+
+  override def job(implicit mirror: reflect.runtime.universe.Mirror): Job = {
+    val jobIn = input.job
+
+    val stageType = reducer.getOrElse(input)
+
+    jobIn.setOutputKeyClass(stageType.outputKeyType)
+    jobIn.setOutputValueClass(stageType.outputValueType)
+    val currentReducer = Option(jobIn.getReducerClass)
+    // Throw an exception if a non-default reducer is found to be on the job already
+    if(currentReducer != Some(classOf[Reducer[_,_,_,_]])) {
+      throw new IllegalArgumentException(
+        "Attempted to set a reducer on a Hadoop job, but found one set on the job already. " +
+          "Are you calling reduce() twice?"
+      )
+    }
+    reducer.foreach(r => jobIn.setReducerClass(r.clazz))
+    jobIn.setNumReduceTasks(numReducers)
+    jobIn
+  }
+}
+
+/**
+  * BaseSyntax provides implicit conversions and operations which are required across a range of applications
+  */
+trait BaseSyntax {
+
+  implicit def optionMapper[T,R](opt: Option[T])(implicit conv: T => R): Option[R] = opt.map(conv)
+
+}
+
+/**
+  * HadoopConversions provides implicit conversions specific to Hadoop classes
+  */
+trait HadoopConversions {
+
+  implicit def stringToPath(p: String): Path = new Path(p)
+
+}
+
+/**
+  * WrappingSyntax provides implicit conversions and operations for objects wrapping Hadoop/MapReduce classes
+  */
+trait WrappingSyntax extends BaseSyntax { self: BaseSyntax =>
+
+  implicit def mapperToWrapper[KI:TT,VI:TT,KO:TT,VO:TT](m: Mapper[KI,VI,KO,VO]): WrappedMapper[KI,VI,KO,VO] = WrappedMapper(m)
+
+  implicit def reducerToWrapper[KI:TT,VI:TT,KO:TT,VO:TT](r: Reducer[KI,VI,KO,VO]): WrappedReducer[KI,VI,KO,VO] = WrappedReducer(r)
+
+  implicit def partitionerToWrapper[KI:TT,VI:TT](p: Partitioner[KI,VI]): WrappedPartitioner[KI,VI] = WrappedPartitioner(p)
+
+}
+
+/**
+  * CompositionSyntax provides various operations for manipulating various stages of a MapReduce Job in order to
+  * define a job in a type-safe and functional way.
+  */
+trait CompositionSyntax extends WrappingSyntax {
+
+  /**
+    * Creates a BaseJob instance which can be chained with other operations to configure a MapReduce Job.
+    *
+    * @param name Name of the MapReduce job
+    * @param caller Class of the invoking class. This can be provided implicitly, such as in the case where
+    *               the enclosing class extends [[WithCallingClass]]
+    */
+  def job(name: String)(implicit caller: Class[_]): BaseJob = BaseJob(name, callingClass = caller)
+
+  /**
+    * Creates a BaseJob instance which can be chained with other operations to configure a MapReduce Job.
+    *
+    * @param name Name of the MapReduce job
+    * @param initialConfig Configuration object to supply to the constructor of the contained MapReduce Job
+    * @param caller Class of the invoking class. This can be provided implicitly, such as in the case where
+    *               the enclosing class extends [[WithCallingClass]]
+    */
+  def job(name: String, initialConfig: Configuration)(implicit caller: Class[_]): BaseJob = BaseJob(name, Some(initialConfig), caller)
+
+  implicit class BaseJobSyntax(job: BaseJob) {
+    /**
+      * file is a general-purpose means of reading an input file, but requires the specification of a
+      * FileInputFormat of the correct type in order to be applied. The type of the file determines what
+      * the type constraints on the input types of the Mapper will be.
+      *
+      * @param path Path of the file to read in
+      * @param inputFormat Hadoop FileInputFormat[KI,VI] which determines how to parse the file
+      * @tparam KI Key Input type of the file - Will determine the input key type of the Mapper stage
+      * @tparam VI Value Input type of the file - Will determine the input value type of the Mapper stage
+      */
+    def file[KI:TT, VI:TT](path: Path,
+                           inputFormat: Class[_<:FileInputFormat[KI,VI]]): FileInputDefinition[KI,VI] = {
+      FileInputDefinition(job, path, inputFormat)
+    }
+
+    /**
+      * sequenceFile creates a FileInputDefinition specifically using the SequenceFileInputFormat for the
+      * specified key and value types.
+      *
+      * @param path Path of the file to read in
+      * @tparam KI Key Input type of the file - Will determine the input key type of the Mapper stage
+      * @tparam VI Value Input type of the file - Will determine the input value type of the Mapper stage
+      */
+    def sequenceFile[KI:TT, VI:TT](path: Path): FileInputDefinition[KI,VI] = {
+      FileInputDefinition(job, path, classOf[SequenceFileInputFormat[KI,VI]])
+    }
+
+    /**
+      * textFile creates a FileInputDefinition specifically using the TextInputFormat. The resulting
+      * key type is LongWritable, and the value type is Text.
+      *
+      * @param path Path of the file to read in
+      */
+    def textFile(path: Path): FileInputDefinition[LongWritable, Text] = {
+      FileInputDefinition(job, path, classOf[TextInputFormat])
+    }
+  }
+
+  /**
+    * This syntax class provides the main operations for MapReduce jobs: mapping, reducing, partitioning, and combining.
+    */
+  implicit class StageSyntax[K:TT,V:TT](stage: Stage[K,V]) {
+    def map[KO,VO](mapper: WrappedMapper[K,V,KO,VO]): MapStage[K, V, KO, VO] = MapStage(stage, Some(mapper))
+    def combine(combiner: WrappedReducer[K,V,K,V]): CombineStage[K,V] = CombineStage(stage, Some(combiner))
+    def partition(partitioner: WrappedPartitioner[K,V]): PartitionStage[K,V] = PartitionStage(stage, Some(partitioner))
+    def reduce[KO,VO](reducer: WrappedReducer[K,V,KO,VO], numReducers: Int = 1): ReduceStage[K,V,KO,VO] = ReduceStage(stage, Some(reducer), numReducers)
+    def reduce(numReducers: Int = 1): ReduceStage[K,V,K,V] = ReduceStage(stage, None, numReducers)
+  }
+
+  /**
+    * Set of syntax operations which are valid only on "output" stages. These operations are mostly concerned with
+    * determining the output location and format for the job.
+    *
+    * @param outputStage Input "output" stage (usually a reduce stage, but can be a map with no reduce)
+    * @tparam KO Output key type of the output stage
+    * @tparam VO Output value type of the output stage
+    */
+  implicit class OutputStageSyntax[KO, VO](outputStage: Stage[KO,VO]) {
+    /**
+      * Bind the output path of the job to a file, and optionally delete the file(s) currently present
+      * at that location
+      *
+      * @param path Path of output directory
+      * @param deleteExisting If true, deletes the contents of the output directory before running the job
+      */
+    def setOutputAsFile(path: Path, deleteExisting: Boolean = true): FileOutputDefinition[KO,VO] = {
+      FileOutputDefinition(outputStage, path, deleteExisting = deleteExisting)
+    }
+
+    /**
+      * Sets the output destination, configures output to be TextOutputFormat, and runs the MapReduce job immediately.
+      *
+      * @param path Path of output directory
+      * @param deleteExisting If true, deletes the contents of the output directory before running the job
+      * @param verbose If true, enables verbose output from the framework while running
+      * @param mirror Implicit type mirror used for resolving runtime types of arguments
+      */
+    def saveAsTextFile(path: Path, deleteExisting: Boolean = true, verbose: Boolean = true)
+                      (implicit mirror: reflect.runtime.universe.Mirror): Boolean = {
+      val jobWithOutput = FileOutputDefinition(
+        outputStage, path, outputFormat = classOf[TextOutputFormat[KO,VO]], deleteExisting)
+      jobWithOutput.run(verbose)
+    }
+
+    /**
+      * Sets the output destination, configures output to be SequenceFileOutputFormat, and runs the MapReduce job immediately.
+      *
+      * @param path Path of output directory
+      * @param deleteExisting If true, deletes the contents of the output directory before running the job
+      * @param verbose If true, enables verbose output from the framework while running
+      * @param mirror Implicit type mirror used for resolving runtime types of arguments
+      */
+    def saveAsSequenceFile(path: Path, deleteExisting: Boolean = true, verbose: Boolean = true)
+                          (implicit mirror: reflect.runtime.universe.Mirror): Boolean = {
+      val jobWithOutput = FileOutputDefinition(
+        outputStage, path, outputFormat = classOf[SequenceFileOutputFormat[KO,VO]], deleteExisting)
+      jobWithOutput.run(verbose)
+    }
+  }
+
+  /**
+    * Set of syntax operations which are valid only on stages which have a key class extending
+    * WritableComparable. These operations are mostly concerned with determining the output location and format for the job.
+    *
+    * @param outputStage Output stage
+    * @tparam KO Output key type of the stage. Must extend WritableComparable
+    * @tparam VO Output value type of the stage
+    */
+  implicit class WritableComparableOutputStageSyntax[KO<:WritableComparable[_],VO](outputStage: Stage[KO,VO]) {
+
+    /**
+      * Sets the output destination, configures output to be MapFileOutputFormat, and runs the MapReduce job immediately.
+      *
+      * @param path Path of output directory
+      * @param deleteExisting If true, deletes the contents of the output directory before running the job
+      * @param verbose If true, enables verbose output from the framework while running
+      * @param mirror Implicit type mirror used for resolving runtime types of arguments
+      */
+    def saveAsMapFile(path: Path, deleteExisting: Boolean = true, verbose: Boolean = true)
+                     (implicit mirror: reflect.runtime.universe.Mirror): Boolean = {
+      val jobWithOutput = FileOutputDefinition(
+        outputStage, path, outputFormat = classOf[MapFileOutputFormat], deleteExisting)
+      jobWithOutput.run(verbose)
+    }
+
+  }
+
+}
+
+/**
+  * MapReduceSugar brings together the above syntax and utility traits into a single trait which can be mixed
+  * in to a class to provide a convenient way to specify MapReduce jobs in Scala.
+  */
+trait MapReduceSugar
+  extends CompositionSyntax
+    with WithCallingClass
+    with WithMirror
+    with WritableConversions
+    with HadoopConversions
+    with PairWritableConversions
+

--- a/src/main/scala/io/bespin/scala/mapreduce/wordcount/WordCount.scala
+++ b/src/main/scala/io/bespin/scala/mapreduce/wordcount/WordCount.scala
@@ -1,74 +1,47 @@
 package io.bespin.scala.mapreduce.wordcount
 
+import io.bespin.scala.mapreduce.util.{BaseConfiguredTool, MapReduceSugar, TypedMapper, TypedReducer}
 import io.bespin.scala.util.Tokenizer
-import io.bespin.scala.util.WritableConversions
-
-import java.util.StringTokenizer
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable._
-
-import org.apache.hadoop.conf._
-import org.apache.hadoop.fs._
 import org.apache.hadoop.io._
-import org.apache.hadoop.mapreduce._
-import org.apache.hadoop.mapreduce.lib.input._
-import org.apache.hadoop.mapreduce.lib.output._
-import org.apache.hadoop.util.Tool
-import org.apache.hadoop.util.ToolRunner
-import org.apache.log4j._
 import org.rogach.scallop._
 
-class Conf(args: Seq[String]) extends ScallopConf(args) {
-  mainOptions = Seq(input, output, reducers)
-  val input = opt[String](descr = "input path", required = true)
-  val output = opt[String](descr = "output path", required = true)
-  val reducers = opt[Int](descr = "number of reducers", required = false, default = Some(1))
-  val imc = opt[Boolean](descr = "use in-mapper combining", required = false)
-}
+import scala.collection.mutable
 
-object WordCount extends Configured with Tool with WritableConversions with Tokenizer {
-  val log = Logger.getLogger(getClass().getName())
+object WordCount extends BaseConfiguredTool with Tokenizer with MapReduceSugar {
 
-  class MyMapper extends Mapper[LongWritable, Text, Text, IntWritable] {
-    override def map(key: LongWritable, value: Text,
-                     context: Mapper[LongWritable, Text, Text, IntWritable]#Context) = {
+
+  object MyMapper extends TypedMapper[LongWritable, Text, Text, IntWritable] {
+    override def map(key: LongWritable, value: Text, context: Context) = {
       tokenize(value).foreach(word => context.write(word, 1))
     }
   }
 
-  class MyMapperIMC extends Mapper[LongWritable, Text, Text, IntWritable] {
-    val counts = new HashMap[String, Int]().withDefaultValue(0)
+  object MyMapperIMC extends TypedMapper[LongWritable, Text, Text, IntWritable] {
+    val counts = new mutable.HashMap[String, Int]().withDefaultValue(0)
 
-    override def map(key: LongWritable, value: Text,
-                     context: Mapper[LongWritable, Text, Text, IntWritable]#Context) = {
+    override def map(key: LongWritable, value: Text, context: Context) = {
       tokenize(value).foreach(word => counts.put(word, counts(word) + 1))
     }
 
-    override def cleanup(context: Mapper[LongWritable, Text, Text, IntWritable]#Context) = {
+    override def cleanup(context: Context) = {
       counts.foreach({ case (k, v) => context.write(k, v) })
     }
   }
 
-  class MyReducer extends Reducer[Text, IntWritable, Text, IntWritable] {
-    override def reduce(key: Text, values: java.lang.Iterable[IntWritable],
-                        context: Reducer[Text, IntWritable, Text, IntWritable]#Context) = {
-      // Although it is possible to write the reducer in a functional style (e.g., with foldLeft),
-      // an imperative implementation is clearer for two reasons:
-      //
-      //   (1) The MapReduce framework supplies an iterable over writable objects; since writable
-      //       are container objects, it simply returns (a reference to) the same object each time
-      //       but with a different payload inside it.
-      //   (2) Implicit writable conversions in WritableConversions.
-      //
-      // The combination of both means that a functional implementation may have unpredictable
-      // behavior when the two issues interact.
-      var sum = 0
-      for (value <- values.asScala) {
-        sum += value
-      }
+  object MyReducer extends TypedReducer[Text, IntWritable, Text, IntWritable] {
+    override def reduce(key: Text, values: Iterable[IntWritable], context: Context) = {
+      val sum = values.foldLeft(0)(_ + _)
       context.write(key, sum)
     }
+  }
+
+  private class Conf(args: Seq[String]) extends ScallopConf(args) {
+    lazy val input = opt[String](descr = "input path", required = true)
+    lazy val output = opt[String](descr = "output path", required = true)
+    lazy val reducers = opt[Int](descr = "number of reducers", required = false, default = Some(1))
+    lazy val imc = opt[Boolean](descr = "use in-mapper combining", required = false, default = Some(false))
+
+    mainOptions = Seq(input, output, reducers)
   }
 
   override def run(argv: Array[String]) : Int = {
@@ -79,38 +52,21 @@ object WordCount extends Configured with Tool with WritableConversions with Toke
     log.info("Number of reducers: " + args.reducers())
     log.info("Use in-mapper combining: " + args.imc())
 
-    val conf = getConf()
-    val job = Job.getInstance(conf)
 
-    FileInputFormat.addInputPath(job, new Path(args.input()))
-    FileOutputFormat.setOutputPath(job, new Path(args.output()))
 
-    job.setJobName("Word Count")
-    job.setJarByClass(this.getClass)
+    val thisJob =
+      job("WordCount", getConf)
+        // Set the input path of the source text file
+        .textFile(args.input())
+        // Map and reduce over the data of the source file
+        .map(if(args.imc()) MyMapperIMC else MyMapper)
+        .combine(MyReducer)
+        .reduce(MyReducer, args.reducers())
 
-    job.setMapOutputKeyClass(classOf[Text])
-    job.setMapOutputValueClass(classOf[IntWritable])
-    job.setOutputKeyClass(classOf[Text])
-    job.setOutputValueClass(classOf[IntWritable])
-    job.setOutputFormatClass(classOf[TextOutputFormat[Text, IntWritable]])
+    time {
+        thisJob.saveAsTextFile(args.output())
+    }
 
-    job.setMapperClass(if (args.imc()) classOf[MyMapperIMC] else classOf[MyMapper])
-    job.setCombinerClass(classOf[MyReducer])
-    job.setReducerClass(classOf[MyReducer])
-
-    job.setNumReduceTasks(args.reducers())
-
-    val outputDir = new Path(args.output())
-    FileSystem.get(conf).delete(outputDir, true)
-
-    val startTime = System.currentTimeMillis()
-    job.waitForCompletion(true)
-    log.info("Job Finished in " + (System.currentTimeMillis() - startTime) / 1000.0 + " seconds")
-
-    return 0
-  }
-
-  def main(args: Array[String]) {
-    ToolRunner.run(this, args)
+    0
   }
 }

--- a/src/main/scala/io/bespin/scala/spark/bigram/BigramCount.scala
+++ b/src/main/scala/io/bespin/scala/spark/bigram/BigramCount.scala
@@ -16,7 +16,7 @@ class Conf(args: Seq[String]) extends ScallopConf(args) with Tokenizer {
 }
 
 object BigramCount extends Tokenizer {
-  val log = Logger.getLogger(getClass().getName())
+  val log = Logger.getLogger(getClass.getName)
 
   def main(argv: Array[String]) {
     val args = new Conf(argv)

--- a/src/main/scala/io/bespin/scala/spark/wordcount/WordCount.scala
+++ b/src/main/scala/io/bespin/scala/spark/wordcount/WordCount.scala
@@ -1,14 +1,12 @@
 package io.bespin.scala.spark.wordcount
 
 import io.bespin.scala.util.Tokenizer
-
-import collection.mutable.HashMap
-
-import org.apache.log4j._
 import org.apache.hadoop.fs._
-import org.apache.spark.SparkContext
-import org.apache.spark.SparkConf
+import org.apache.log4j._
+import org.apache.spark.{SparkConf, SparkContext}
 import org.rogach.scallop._
+
+import scala.collection.mutable
 
 class Conf(args: Seq[String]) extends ScallopConf(args) with Tokenizer {
   mainOptions = Seq(input, output, reducers)
@@ -19,10 +17,10 @@ class Conf(args: Seq[String]) extends ScallopConf(args) with Tokenizer {
 }
 
 object WordCount extends Tokenizer {
-  val log = Logger.getLogger(getClass().getName())
+  val log = Logger.getLogger(getClass.getName)
 
   def wcIter(iter: Iterator[String]): Iterator[(String, Int)] = {
-    val counts = new HashMap[String, Int]() { override def default(key: String) = 0 }
+    val counts = new mutable.HashMap[String, Int]() { override def default(key: String) = 0 }
 
     iter.flatMap(line => tokenize(line))
       .foreach { t => counts.put(t, counts(t) + 1) }

--- a/src/main/scala/io/bespin/scala/util/Tokenizer.scala
+++ b/src/main/scala/io/bespin/scala/util/Tokenizer.scala
@@ -5,9 +5,14 @@ import java.util.StringTokenizer
 import scala.collection.JavaConverters._
 
 trait Tokenizer {
-  def tokenize(s: String): List[String] = {
-    new StringTokenizer(s).asScala.toList
-      .map(_.asInstanceOf[String].toLowerCase().replaceAll("(^[^a-z]+|[^a-z]+$)", ""))
-      .filter(_.length != 0)
+
+  def tokenize(s: String): Seq[String] = {
+    new StringTokenizer(s).asScala
+      .map(_.asInstanceOf[String]
+        .toLowerCase()
+        .replaceAll("(^[^a-z]+|[^a-z]+$)", ""))
+      .withFilter(_.nonEmpty)
+      .toSeq
   }
+
 }

--- a/src/main/scala/io/bespin/scala/util/WritableConversions.scala
+++ b/src/main/scala/io/bespin/scala/util/WritableConversions.scala
@@ -1,23 +1,124 @@
 package io.bespin.scala.util
 
 import org.apache.hadoop.io._
+import tl.lin.data.pair._
 
+import scala.language.implicitConversions
+import scala.reflect.{ClassTag, classTag}
+
+/**
+  * Provides a set of implicit conversions between the Hadoop Writable types and base Scala types
+  */
 trait WritableConversions {
-  implicit def BooleanWritableUnbox(v: BooleanWritable) = v.get
-  implicit def BooleanWritableBox  (v: Boolean) = new BooleanWritable(v)
+  implicit def BooleanWritableUnbox(v: BooleanWritable): Boolean = v.get
+  implicit def BooleanWritableBox  (v: Boolean): BooleanWritable = new BooleanWritable(v)
 
-  implicit def DoubleWritableUnbox(v: DoubleWritable) = v.get
-  implicit def DoubleWritableBox  (v: Double) = new DoubleWritable(v)
+  implicit def ShortWritableUnbox(v: ShortWritable): Short = v.get
+  implicit def ShortWritableBox  (v: Short): ShortWritable = new ShortWritable(v)
 
-  implicit def FloatWritableUnbox(v: FloatWritable) = v.get
-  implicit def FloatWritableBox  (v: Float) = new FloatWritable(v)
+  implicit def IntWritableUnbox(v: IntWritable): Int = v.get
+  implicit def IntWritableBox  (v: Int): IntWritable = new IntWritable(v)
 
-  implicit def IntWritableUnbox(v: IntWritable) = v.get
-  implicit def IntWritableBox  (v: Int) = new IntWritable(v)
+  implicit def LongWritableUnbox(v: LongWritable): Long = v.get
+  implicit def LongWritableBox  (v: Long): LongWritable = new LongWritable(v)
 
-  implicit def LongWritableUnbox(v: LongWritable) = v.get
-  implicit def LongWritableBox  (v: Long) = new LongWritable(v)
+  implicit def FloatWritableUnbox(v: FloatWritable): Float = v.get
+  implicit def FloatWritableBox  (v: Float): FloatWritable = new FloatWritable(v)
 
-  implicit def TextUnbox(v: Text) = v.toString
-  implicit def TextBox  (v: String) = new Text(v)
+  implicit def DoubleWritableUnbox(v: DoubleWritable): Double = v.get
+  implicit def DoubleWritableBox  (v: Double): DoubleWritable = new DoubleWritable(v)
+
+  implicit def TextUnbox(v: Text): String = v.toString
+  implicit def TextBox  (v: String): Text = new Text(v)
+
+  /** No implicit unboxing for Objects; have to do it explicitly to prevent confusion over types */
+  def ObjectWritableUnbox[T : ClassTag](v: ObjectWritable): T = {
+    assert(classTag[T].runtimeClass == v.getDeclaredClass)
+    v.get().asInstanceOf[T]
+  }
+  implicit def ObjectWritableBox[T : ClassTag]  (v: T): ObjectWritable = new ObjectWritable(classTag[T].runtimeClass, v)
+}
+
+trait PairWritableConversions {
+
+  implicit def PairOfWritablesUnbox[L <: Writable, R <: Writable](v: PairOfWritables[L, R]): (L, R) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfWritablesBox[L <: Writable, R <: Writable](v: (L, R)): PairOfWritables[L, R] =
+    new PairOfWritables[L,R](v._1, v._2)
+
+  implicit def PairOfObjectsUnbox[L <: Comparable[L], R<: Comparable[R]](v: PairOfObjects[L, R]): (L, R) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectsBox[L <: Comparable[L], R<: Comparable[R]](v: (L, R)): PairOfObjects[L, R] =
+    new PairOfObjects(v._1, v._2)
+
+  implicit def PairOfObjectShortUnbox[L <: Comparable[L]](v: PairOfObjectShort[L]): (L, Short) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectShortBox[L <: Comparable[L]](v: (L, Short)): PairOfObjectShort[L] =
+    new PairOfObjectShort(v._1, v._2)
+
+  implicit def PairOfObjectIntUnbox[L <: Comparable[L]](v: PairOfObjectInt[L]): (L, Int) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectIntBox[L <: Comparable[L]](v: (L, Int)): PairOfObjectInt[L] =
+    new PairOfObjectInt(v._1, v._2)
+
+  implicit def PairOfObjectLongUnbox[L <: Comparable[L]](v: PairOfObjectLong[L]): (L, Long) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectLongBox[L <: Comparable[L]](v: PairOfObjectLong[L]): PairOfObjectLong[L] =
+    new PairOfObjectLong(v._1, v._2)
+
+  implicit def PairOfObjectFloatUnbox[L <: Comparable[L]](v: PairOfObjectFloat[L]): (L, Float) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectFloatBox[L <: Comparable[L]](v: (L, Float)): PairOfObjectFloat[L] =
+    new PairOfObjectFloat(v._1, v._2)
+
+  implicit def PairOfObjectDoubleUnbox[L <: Comparable[L]](v: PairOfObjectDouble[L]): (L, Double) =
+    (v.getLeftElement, v.getRightElement)
+  implicit def PairOfObjectDoubleBox[L <: Comparable[L]](v: (L, Double)): PairOfObjectDouble[L] =
+    new PairOfObjectDouble(v._1, v._2)
+
+  implicit def PairOfStringsUnbox(v: PairOfStrings): (String, String) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfStringsBox(v: (String, String)): PairOfStrings = new PairOfStrings(v._1, v._2)
+
+  implicit def PairOfStringIntUnbox(v: PairOfStringInt): (String, Int) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfStringIntBox(v: (String, Int)): PairOfStringInt = new PairOfStringInt(v._1, v._2)
+
+  implicit def PairOfStringLongUnbox(v: PairOfStringLong): (String, Long) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfStringLongBox(v: (String, Long)): PairOfStringLong = new PairOfStringLong(v._1, v._2)
+
+  implicit def PairOfStringFloatUnbox(v: PairOfStringFloat): (String, Float) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfStringFloatBox(v: (String, Float)): PairOfStringFloat = new PairOfStringFloat(v._1, v._2)
+
+  implicit def PairOfIntsUnbox(v: PairOfInts): (Int, Int) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfIntsBox(v: (Int, Int)): PairOfInts = new PairOfInts(v._1, v._2)
+
+  implicit def PairOfIntLongUnbox(v: PairOfIntLong): (Int, Long) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfIntLongBox(v: (Int, Long)): PairOfIntLong = new PairOfIntLong(v._1, v._2)
+
+  implicit def PairOfIntFloatUnbox(v: PairOfIntFloat): (Int, Float) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfIntFloatBox(v: (Int, Float)): PairOfIntFloat = new PairOfIntFloat(v._1, v._2)
+
+  implicit def PairOfIntStringUnbox(v: PairOfIntString): (Int, String) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfIntStringBox(v: (Int, String)): PairOfIntString = new PairOfIntString(v._1, v._2)
+
+  implicit def PairOfLongsUnbox(v: PairOfLongs): (Long, Long) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfLongsBox(v: (Long, Long)): PairOfLongs = new PairOfLongs(v._1, v._2)
+
+  implicit def PairOfLongIntUnbox(v: PairOfLongInt): (Long, Int) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfLongIntBox(v: (Long, Int)): PairOfLongInt = new PairOfLongInt(v._1, v._2)
+
+  implicit def PairOfLongFloatUnbox(v: PairOfLongFloat): (Long, Float) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfLongFloatBox(v: (Long, Float)): PairOfLongFloat = new PairOfLongFloat(v._1, v._2)
+
+  implicit def PairOfLongStringUnbox(v: PairOfLongString): (Long, String) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfLongStringBox(v: (Long, String)): PairOfLongString = new PairOfLongString(v._1, v._2)
+
+  implicit def PairOfFloatsUnbox(v: PairOfFloats): (Float, Float) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfFloatsBox(v: (Float, Float)): PairOfFloats = new PairOfFloats(v._1, v._2)
+
+  implicit def PairOfFloatIntUnbox(v: PairOfFloatInt): (Float, Int) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfFloatIntBox(v: (Float, Int)): PairOfFloatInt = new PairOfFloatInt(v._1, v._2)
+
+  implicit def PairOfFloatStringUnbox(v: PairOfFloatString): (Float, String) = (v.getLeftElement, v.getRightElement)
+  implicit def PairOfFloatStringBox(v: (Float, String)): PairOfFloatString = new PairOfFloatString(v._1, v._2)
+
 }

--- a/src/test/scala/io.bespin.scala.mapreduce.util/TypedMapperTest.scala
+++ b/src/test/scala/io.bespin.scala.mapreduce.util/TypedMapperTest.scala
@@ -1,0 +1,24 @@
+package io.bespin.scala.mapreduce.util
+
+import org.scalatest.{Matchers, FunSpec}
+import scala.reflect.runtime.universe.typeOf
+
+class TypedMapperTest extends FunSpec with Matchers {
+
+  trait TypeA
+  trait TypeB
+  trait TypeC extends TypeA with TypeB
+
+  describe("A Typed Mapper") {
+    describe("upon creation") {
+      it("should capture the correct runtime output types") {
+        val m = new TypedMapper[TypeA, TypeB, TypeC, TypeB] {}
+        assert(m.kEv.tpe =:= typeOf[TypeC])
+        assert(m.kEv.tpe <:< typeOf[TypeA])
+        assert(m.kEv.tpe <:< typeOf[TypeB])
+        assert(m.vEv.tpe =:= typeOf[TypeB])
+        assert(!(m.vEv.tpe <:< typeOf[TypeA]))
+      }
+    }
+  }
+}

--- a/src/test/scala/io.bespin.scala.mapreduce.util/TypedReducerTest.scala
+++ b/src/test/scala/io.bespin.scala.mapreduce.util/TypedReducerTest.scala
@@ -1,0 +1,25 @@
+package io.bespin.scala.mapreduce.util
+
+import org.scalatest.{Matchers, FunSpec}
+
+import scala.reflect.runtime.universe.typeOf
+
+class TypedReducerTest extends FunSpec with Matchers {
+
+  trait TypeA
+  trait TypeB
+  trait TypeC extends TypeA with TypeB
+  
+  describe("A Typed Reducer") {
+    describe("upon creation") {
+      it("should capture the correct runtime output types") {
+        val m = new TypedReducer[TypeA, TypeB, TypeC, TypeB] {}
+        assert(m.kEv.tpe =:= typeOf[TypeC])
+        assert(m.kEv.tpe <:< typeOf[TypeA])
+        assert(m.kEv.tpe <:< typeOf[TypeB])
+        assert(m.vEv.tpe =:= typeOf[TypeB])
+        assert(!(m.vEv.tpe <:< typeOf[TypeA]))
+      }
+    }
+  }
+}

--- a/src/test/scala/io/bespin/scala/util/WritableConversionsTest.scala
+++ b/src/test/scala/io/bespin/scala/util/WritableConversionsTest.scala
@@ -1,0 +1,131 @@
+package io.bespin.scala.util
+
+import org.apache.hadoop.io._
+import org.scalatest.{FunSpec, Matchers}
+
+class WritableConversionsTest extends FunSpec with Matchers {
+
+  val wc = new WritableConversions {}
+
+  describe("ObjectWritable conversions") {
+    import wc._
+    case class A(v: String)
+    case class B(v: Int)
+
+    it("should correctly box ObjectWritable") {
+      val obj = A("test")
+      val boxed: ObjectWritable = obj
+      boxed.get() shouldBe obj
+    }
+    it("should correctly unbox ObjectWritable") {
+      val boxed = new ObjectWritable(classOf[A], A("test"))
+      val unboxed = wc.ObjectWritableUnbox[A](boxed)
+      unboxed shouldBe A("test")
+    }
+    it("should throw exception if unboxing to incompatible type") {
+      val boxed = new ObjectWritable(classOf[A], A("test"))
+      intercept [AssertionError] {
+        wc.ObjectWritableUnbox[B](boxed)
+      }
+    }
+  }
+
+  describe("BooleanWritable conversions") {
+    import wc._
+    it("should correctly box BooleanWritable") {
+      val boxed: BooleanWritable = true
+      boxed.get() shouldBe true
+    }
+
+    it("should correctly unbox BooleanWritable") {
+      val boxed = new BooleanWritable(true)
+      val unboxed: Boolean = boxed
+      unboxed shouldBe true
+    }
+  }
+
+  describe("ShortWritable conversions") {
+    import wc._
+    it("should correctly box ShortWritable") {
+      val boxed: ShortWritable = 5.toShort
+      boxed.get() shouldBe 5
+    }
+
+    it("should correctly unbox ShortWritable") {
+      val boxed = new ShortWritable(5)
+      val unboxed: Short = boxed
+      unboxed shouldBe 5
+    }
+  }
+
+  describe("IntWritable conversions") {
+    import wc._
+    it("should correctly box IntWritable") {
+      val boxed: IntWritable = 5
+      boxed.get() shouldBe 5
+    }
+
+    it("should correctly unbox IntWritable") {
+      val boxed = new IntWritable(5)
+      val unboxed: Int = boxed
+      unboxed shouldBe 5
+    }
+  }
+
+  describe("LongWritable conversions") {
+    import wc._
+    it("should correctly box LongWritable") {
+      val boxed: LongWritable = Long.MaxValue
+      boxed.get() shouldBe Long.MaxValue
+    }
+
+    it("should correctly unbox LongWritable") {
+      val boxed = new LongWritable(Long.MaxValue)
+      val unboxed: Long = boxed
+      unboxed shouldBe Long.MaxValue
+    }
+  }
+
+  describe("FloatWritable conversions") {
+    import wc._
+    it("should correctly box FloatWritable") {
+      val boxed: FloatWritable = 5.5f
+      boxed.get() shouldBe 5.5d
+    }
+
+    it("should correctly unbox FloatWritable") {
+      val boxed = new FloatWritable(5.5f)
+      val unboxed: Float = boxed
+      unboxed shouldBe 5.5d
+    }
+  }
+
+  describe("DoubleWritable conversions") {
+    import wc._
+    it("should correctly box DoubleWritable") {
+      val boxed: DoubleWritable = 5.5d
+      boxed.get() shouldBe 5.5d
+    }
+
+    it("should correctly unbox DoubleWritable") {
+      val boxed = new DoubleWritable(5.5d)
+      val unboxed: Double = boxed
+      unboxed shouldBe 5.5d
+    }
+  }
+
+  describe("Text conversions") {
+    import wc._
+    it("should correctly box Text") {
+      val boxed: Text = "testString"
+      boxed.toString shouldBe "testString"
+    }
+
+    it("should correctly unbox Text") {
+      val boxed = new Text("testString")
+      val unboxed: String = boxed
+      unboxed shouldBe "testString"
+    }
+  }
+
+}


### PR DESCRIPTION
Addition of syntactic sugar in Scala for MapReduce classes, as well as Scala implementations of all Java MapReduce applications.

In addition to the implementations, local integration tests were written
to verify the correctness of the original Java implementations
running in local mode, as well as ensuring that the Scala
implementations returned the same results.
