### PR TITLE
[CLOSES #12] Correct spelling mistakes for 'adjacency'

### DIFF
--- a/src/main/java/io/bespin/java/mapreduce/bfs/BfsNode.java
+++ b/src/main/java/io/bespin/java/mapreduce/bfs/BfsNode.java
@@ -50,7 +50,7 @@ public class BfsNode implements Writable {
   private Type type;
   private int nodeid;
   private int distance;
-  private ArrayListOfIntsWritable adjacenyList;
+  private ArrayListOfIntsWritable adjacencyList;
 
   public BfsNode() {}
 
@@ -70,12 +70,12 @@ public class BfsNode implements Writable {
     nodeid = n;
   }
 
-  public ArrayListOfIntsWritable getAdjacenyList() {
-    return adjacenyList;
+  public ArrayListOfIntsWritable getAdjacencyList() {
+    return adjacencyList;
   }
 
   public void setAdjacencyList(ArrayListOfIntsWritable l) {
-    adjacenyList = l;
+    adjacencyList = l;
   }
 
   public Type getType() {
@@ -107,8 +107,8 @@ public class BfsNode implements Writable {
       distance = in.readInt();
     }
 
-    adjacenyList = new ArrayListOfIntsWritable();
-    adjacenyList.readFields(in);
+    adjacencyList = new ArrayListOfIntsWritable();
+    adjacencyList.readFields(in);
   }
 
   /**
@@ -131,13 +131,13 @@ public class BfsNode implements Writable {
       out.writeInt(distance);
     }
 
-    adjacenyList.write(out);
+    adjacencyList.write(out);
   }
 
   @Override
   public String toString() {
-    return String.format("{%d %d %s}", nodeid, distance, (adjacenyList == null ? "[]"
-        : adjacenyList.toString(10)));
+    return String.format("{%d %d %s}", nodeid, distance, (adjacencyList == null ? "[]"
+        : adjacencyList.toString(10)));
   }
 
   /**

--- a/src/main/java/io/bespin/java/mapreduce/bfs/IterateBfs.java
+++ b/src/main/java/io/bespin/java/mapreduce/bfs/IterateBfs.java
@@ -68,7 +68,7 @@ public class IterateBfs extends Configured implements Tool {
       // Pass along node structure.
       intermediateStructure.setNodeId(node.getNodeId());
       intermediateStructure.setType(BfsNode.Type.Structure);
-      intermediateStructure.setAdjacencyList(node.getAdjacenyList());
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList());
 
       context.write(nid, intermediateStructure);
 
@@ -80,7 +80,7 @@ public class IterateBfs extends Configured implements Tool {
       // Retain distance to self.
       map.put(nid.get(), node.getDistance());
 
-      ArrayListOfInts adj = node.getAdjacenyList();
+      ArrayListOfInts adj = node.getAdjacencyList();
       int dist = node.getDistance() + 1;
       // Keep track of shortest distance to neighbors.
       for (int i = 0; i < adj.size(); i++) {
@@ -130,7 +130,7 @@ public class IterateBfs extends Configured implements Tool {
 
         if (n.getType() == BfsNode.Type.Structure) {
           // This is the structure; update accordingly.
-          ArrayListOfIntsWritable list = n.getAdjacenyList();
+          ArrayListOfIntsWritable list = n.getAdjacencyList();
           structureReceived++;
 
           int arr[] = new int[list.size()];

--- a/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankNode.java
+++ b/src/main/java/io/bespin/java/mapreduce/pagerank/PageRankNode.java
@@ -51,7 +51,7 @@ public class PageRankNode implements Writable {
   private Type type;
   private int nodeid;
   private float pagerank;
-  private ArrayListOfIntsWritable adjacenyList;
+  private ArrayListOfIntsWritable adjacencyList;
 
   public PageRankNode() {}
 
@@ -71,12 +71,12 @@ public class PageRankNode implements Writable {
     this.nodeid = n;
   }
 
-  public ArrayListOfIntsWritable getAdjacenyList() {
-    return adjacenyList;
+  public ArrayListOfIntsWritable getAdjacencyList() {
+    return adjacencyList;
   }
 
   public void setAdjacencyList(ArrayListOfIntsWritable list) {
-    this.adjacenyList = list;
+    this.adjacencyList = list;
   }
 
   public Type getType() {
@@ -108,8 +108,8 @@ public class PageRankNode implements Writable {
       pagerank = in.readFloat();
     }
 
-    adjacenyList = new ArrayListOfIntsWritable();
-    adjacenyList.readFields(in);
+    adjacencyList = new ArrayListOfIntsWritable();
+    adjacencyList.readFields(in);
   }
 
   /**
@@ -132,13 +132,13 @@ public class PageRankNode implements Writable {
       out.writeFloat(pagerank);
     }
 
-    adjacenyList.write(out);
+    adjacencyList.write(out);
   }
 
   @Override
   public String toString() {
-    return String.format("{%d %.4f %s}", nodeid, pagerank, (adjacenyList == null ? "[]"
-        : adjacenyList.toString(10)));
+    return String.format("{%d %.4f %s}", nodeid, pagerank, (adjacencyList == null ? "[]"
+        : adjacencyList.toString(10)));
   }
 
   /**

--- a/src/main/java/io/bespin/java/mapreduce/pagerank/RunPageRankBasic.java
+++ b/src/main/java/io/bespin/java/mapreduce/pagerank/RunPageRankBasic.java
@@ -97,16 +97,16 @@ public class RunPageRankBasic extends Configured implements Tool {
       // Pass along node structure.
       intermediateStructure.setNodeId(node.getNodeId());
       intermediateStructure.setType(PageRankNode.Type.Structure);
-      intermediateStructure.setAdjacencyList(node.getAdjacenyList());
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList());
 
       context.write(nid, intermediateStructure);
 
       int massMessages = 0;
 
       // Distribute PageRank mass to neighbors (along outgoing edges).
-      if (node.getAdjacenyList().size() > 0) {
+      if (node.getAdjacencyList().size() > 0) {
         // Each neighbor gets an equal share of PageRank mass.
-        ArrayListOfIntsWritable list = node.getAdjacenyList();
+        ArrayListOfIntsWritable list = node.getAdjacencyList();
         float mass = node.getPageRank() - (float) StrictMath.log(list.size());
 
         context.getCounter(PageRank.edges).increment(list.size());
@@ -152,7 +152,7 @@ public class RunPageRankBasic extends Configured implements Tool {
       // Pass along node structure.
       intermediateStructure.setNodeId(node.getNodeId());
       intermediateStructure.setType(PageRankNode.Type.Structure);
-      intermediateStructure.setAdjacencyList(node.getAdjacenyList());
+      intermediateStructure.setAdjacencyList(node.getAdjacencyList());
 
       context.write(nid, intermediateStructure);
 
@@ -160,9 +160,9 @@ public class RunPageRankBasic extends Configured implements Tool {
       int massMessagesSaved = 0;
 
       // Distribute PageRank mass to neighbors (along outgoing edges).
-      if (node.getAdjacenyList().size() > 0) {
+      if (node.getAdjacencyList().size() > 0) {
         // Each neighbor gets an equal share of PageRank mass.
-        ArrayListOfIntsWritable list = node.getAdjacenyList();
+        ArrayListOfIntsWritable list = node.getAdjacencyList();
         float mass = node.getPageRank() - (float) StrictMath.log(list.size());
 
         context.getCounter(PageRank.edges).increment(list.size());
@@ -268,7 +268,7 @@ public class RunPageRankBasic extends Configured implements Tool {
 
         if (n.getType().equals(PageRankNode.Type.Structure)) {
           // This is the structure; update accordingly.
-          ArrayListOfIntsWritable list = n.getAdjacenyList();
+          ArrayListOfIntsWritable list = n.getAdjacencyList();
           structureReceived++;
 
           node.setAdjacencyList(list);

--- a/src/main/java/io/bespin/java/mapreduce/pagerank/RunPageRankSchimmy.java
+++ b/src/main/java/io/bespin/java/mapreduce/pagerank/RunPageRankSchimmy.java
@@ -101,9 +101,9 @@ public class RunPageRankSchimmy extends Configured implements Tool {
       int massMessages = 0;
 
       // Distribute PageRank mass to neighbors (along outgoing edges).
-      if (node.getAdjacenyList().size() > 0) {
+      if (node.getAdjacencyList().size() > 0) {
         // Each neighbor gets an equal share of PageRank mass.
-        ArrayListOfIntsWritable list = node.getAdjacenyList();
+        ArrayListOfIntsWritable list = node.getAdjacencyList();
         float mass = node.getPageRank() - (float) StrictMath.log(list.size());
 
         // Iterate over neighbors.
@@ -135,9 +135,9 @@ public class RunPageRankSchimmy extends Configured implements Tool {
       int massMessagesSaved = 0;
 
       // Distribute PageRank mass to neighbors (along outgoing edges).
-      if (node.getAdjacenyList().size() > 0) {
+      if (node.getAdjacencyList().size() > 0) {
         // Each neighbor gets an equal share of PageRank mass.
-        ArrayListOfIntsWritable list = node.getAdjacenyList();
+        ArrayListOfIntsWritable list = node.getAdjacencyList();
         float mass = node.getPageRank() - (float) StrictMath.log(list.size());
 
         // Iterate over neighbors.


### PR DESCRIPTION
Using find / replace in text editor, replaced all misspellings in all files for the misspelling "adjaceny" with correction "adjacency".